### PR TITLE
Using serde to save the world

### DIFF
--- a/src/app/validate/src/check_chunks.rs
+++ b/src/app/validate/src/check_chunks.rs
@@ -25,7 +25,7 @@ pub fn check_chunks(state: &ServerState) -> Result<(), String> {
             if chunk_format_hash_str != Chunk::type_hash() {
                 error!(
                     "Chunk format hash mismatch. Expected 0X{:0X}, got 0X{:0X}. This likely means that the chunk format has changed since saving. If you have \
-                    recently updated Temper you will have to go back to the older version until a world format converter is implemented.)",
+                    recently updated Temper you will have to go back to the older version until a world format converter is implemented.",
                     Chunk::type_hash(),
                     chunk_format_hash_str
                 );
@@ -36,7 +36,7 @@ pub fn check_chunks(state: &ServerState) -> Result<(), String> {
                 "Could not find 'chunk-format-hash' in metadata. This likely means that the world was saved with an older version of Temper that did not include this metadata, or that the metadata is corrupted."
             );
             error!(
-                "If you have recently updated Temper you will have to go back to the older version until a world format converter is implemented.)"
+                "If you have recently updated Temper you will have to go back to the older version until a world format converter is implemented."
             );
             exit(1);
         }
@@ -100,12 +100,12 @@ pub fn check_chunks(state: &ServerState) -> Result<(), String> {
                 exit(1);
             }
         }
-        if let Err(e) = bitcode::decode::<Chunk>(&data) {
+        if let Err(e) = bitcode::deserialize::<Chunk>(&data) {
             progress_bar.finish();
             error!("Chunk {} failed to decode: {}", decoded_key, e);
             error!(
                 "This generally means that the chunk format has changed since saving. If you have \
-                recently updated Temper you will have to go back to the older version until a world format converter is implemented.)"
+                recently updated Temper you will have to go back to the older version until a world format converter is implemented."
             );
             exit(1);
         }

--- a/src/base/logging/src/tui_formatter.rs
+++ b/src/base/logging/src/tui_formatter.rs
@@ -25,7 +25,7 @@ impl LogFormatter for TuiTracingFormatter {
 
         spans.push(
             evt.timestamp
-                .format("%Y-%m-%d %H:%M:%S | ")
+                .strftime("%Y-%m-%d %H:%M:%S | ")
                 .to_string()
                 .dim(),
         );

--- a/src/core/src/block_state_id.rs
+++ b/src/core/src/block_state_id.rs
@@ -1,6 +1,5 @@
 use crate::block_data::BlockData;
 use ahash::RandomState;
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};

--- a/src/core/src/block_state_id.rs
+++ b/src/core/src/block_state_id.rs
@@ -3,6 +3,7 @@ use ahash::RandomState;
 use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
 use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::process::exit;
@@ -53,7 +54,7 @@ pub fn create_block_mappings() -> (Vec<BlockData>, HashMap<BlockData, i32, Rando
 ///
 /// This should be used over `BlockData` in most cases, as it's much more efficient to store and pass around.
 /// You can also generate a block's id at runtime with the [temper_macros::block!] macro.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Encode, Decode, DeepSizeOf, TypeHash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, DeepSizeOf, TypeHash)]
 pub struct BlockStateId(u32);
 
 impl BlockStateId {

--- a/src/core/src/pos.rs
+++ b/src/core/src/pos.rs
@@ -11,8 +11,8 @@ use bevy_math::U8Vec3;
 use bevy_math::Vec2Swizzles;
 use bevy_math::Vec3Swizzles;
 use bevy_math::{DVec3, I16Vec3};
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde::{Deserialize, Serialize};
 use temper_codec::net_types::network_position::NetworkPosition;
 use type_hash::TypeHash;
 
@@ -92,7 +92,7 @@ impl Add<(i32, i32, i32)> for BlockPos {
     }
 }
 
-#[derive(Clone, Copy, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, Copy, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct ChunkHeight {
     pub min_y: i16,
     pub height: u16,

--- a/src/world/db/src/chunks.rs
+++ b/src/world/db/src/chunks.rs
@@ -3,9 +3,9 @@ use temper_config::server_config::get_global_config;
 use temper_core::dimension::Dimension;
 use temper_core::pos::ChunkPos;
 use temper_storage::lmdb::LmdbBackend;
+use temper_world_format::Chunk;
 use temper_world_format::errors::WorldError;
 use temper_world_format::errors::WorldError::CorruptedChunkData;
-use temper_world_format::Chunk;
 use tracing::warn;
 use yazi::CompressionLevel;
 

--- a/src/world/db/src/chunks.rs
+++ b/src/world/db/src/chunks.rs
@@ -3,9 +3,9 @@ use temper_config::server_config::get_global_config;
 use temper_core::dimension::Dimension;
 use temper_core::pos::ChunkPos;
 use temper_storage::lmdb::LmdbBackend;
-use temper_world_format::Chunk;
 use temper_world_format::errors::WorldError;
 use temper_world_format::errors::WorldError::CorruptedChunkData;
+use temper_world_format::Chunk;
 use tracing::warn;
 use yazi::CompressionLevel;
 
@@ -19,7 +19,7 @@ pub fn save_chunk_internal(
         storage.create_table("chunks".to_string())?;
     }
     let as_bytes = yazi::compress(
-        &bitcode::encode(chunk),
+        &bitcode::serialize(chunk).expect("Unable to serialize chunk"),
         yazi::Format::Zlib,
         CompressionLevel::BestSpeed,
     )?;
@@ -47,7 +47,7 @@ pub fn load_chunk_internal(
                     warn!("Chunk data does not have a checksum, skipping verification.");
                 }
             }
-            let chunk: Chunk = bitcode::decode(&data)
+            let chunk: Chunk = bitcode::deserialize(&data)
                 .map_err(|e| WorldError::BitcodeDecodeError(e.to_string()))?;
             Ok(chunk)
         }

--- a/src/world/db/src/chunks.rs
+++ b/src/world/db/src/chunks.rs
@@ -48,7 +48,7 @@ pub fn load_chunk_internal(
                 }
             }
             let chunk: Chunk = bitcode::deserialize(&data)
-                .map_err(|e| WorldError::BitcodeDecodeError(e.to_string()))?;
+                .map_err(|e| WorldError::BitcodeDeserializeError(e.to_string()))?;
             Ok(chunk)
         }
         None => Err(WorldError::ChunkNotFound),

--- a/src/world/format/Cargo.toml
+++ b/src/world/format/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 bitcode_derive = { workspace = true }
-bitcode = { workspace = true }
+bitcode = { workspace = true, features = ["serde"] }
 temper-codec = { workspace = true }
 temper-macros = { workspace = true }
 deepsize = { workspace = true }

--- a/src/world/format/Cargo.toml
+++ b/src/world/format/Cargo.toml
@@ -22,3 +22,15 @@ serde = { workspace = true }
 bytemuck = { workspace = true }
 tokio = { workspace = true }
 type_hash = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+rand = { workspace = true }
+
+[[bench]]
+
+name = "bench"
+harness = false
+
+
+

--- a/src/world/format/benches/bench.rs
+++ b/src/world/format/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 mod serialize;
 
 fn world_format_bench(c: &mut Criterion) {

--- a/src/world/format/benches/bench.rs
+++ b/src/world/format/benches/bench.rs
@@ -1,0 +1,9 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+mod serialize;
+
+fn world_format_bench(mut c: &mut Criterion) {
+    serialize::bench_serialize_world(&mut c);
+}
+
+criterion_group!(benches, world_format_bench);
+criterion_main!(benches);

--- a/src/world/format/benches/bench.rs
+++ b/src/world/format/benches/bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 mod serialize;
 
-fn world_format_bench(mut c: &mut Criterion) {
-    serialize::bench_serialize_world(&mut c);
+fn world_format_bench(c: &mut Criterion) {
+    serialize::bench_serialize_world(c);
 }
 
 criterion_group!(benches, world_format_bench);

--- a/src/world/format/benches/serialize.rs
+++ b/src/world/format/benches/serialize.rs
@@ -1,0 +1,38 @@
+use criterion::Criterion;
+use std::hint::black_box;
+use temper_core::block_state_id::BlockStateId;
+use temper_core::pos::{ChunkBlockPos, ChunkHeight};
+use temper_world_format::Chunk;
+
+fn serialize_chunk(chunk: &mut Chunk) -> Vec<u8> {
+    black_box(bitcode::encode(black_box(chunk)))
+}
+
+pub fn bench_serialize_world(c: &mut Criterion) {
+    let mut chunk = Chunk::new_empty_with_height(ChunkHeight::new(-64, 384));
+    for x in 0..16 {
+        for y in -64..320 {
+            for z in 0..16 {
+                if (x + z) % 3 == 0 {
+                    chunk.set_block(
+                        ChunkBlockPos::new(x, y, z),
+                        BlockStateId::new(rand::random_range(0..20_000)),
+                    )
+                }
+            }
+        }
+    }
+    c.bench_function("format/Serialize", |b| {
+        b.iter(|| {
+            black_box(serialize_chunk(&mut chunk));
+        })
+    });
+
+    let serialized = serialize_chunk(&mut chunk);
+
+    c.bench_function("format/Deserialize", |b| {
+        b.iter(|| {
+            black_box(bitcode::decode::<Chunk>(black_box(&serialized))).unwrap();
+        })
+    });
+}

--- a/src/world/format/benches/serialize.rs
+++ b/src/world/format/benches/serialize.rs
@@ -5,7 +5,7 @@ use temper_core::pos::{ChunkBlockPos, ChunkHeight};
 use temper_world_format::Chunk;
 
 fn serialize_chunk(chunk: &mut Chunk) -> Vec<u8> {
-    black_box(bitcode::encode(black_box(chunk)))
+    black_box(bitcode::serialize(black_box(chunk)).unwrap())
 }
 
 pub fn bench_serialize_world(c: &mut Criterion) {
@@ -32,7 +32,7 @@ pub fn bench_serialize_world(c: &mut Criterion) {
 
     c.bench_function("format/Deserialize", |b| {
         b.iter(|| {
-            black_box(bitcode::decode::<Chunk>(black_box(&serialized))).unwrap();
+            black_box(bitcode::deserialize::<Chunk>(black_box(&serialized))).unwrap();
         })
     });
 }

--- a/src/world/format/src/errors.rs
+++ b/src/world/format/src/errors.rs
@@ -27,10 +27,10 @@ pub enum WorldError {
     GenericIOError(String),
     #[error("A database error occurred from the world crate: {0}")]
     DatabaseError(StorageError),
-    #[error("There was an error with bitcode's decoding: {0}")]
-    BitcodeDecodeError(String),
-    #[error("There was an error with bitcode's encoding: {0}")]
-    BitcodeEncodeError(String),
+    #[error("There was an error with bitcode's deserializing: {0}")]
+    BitcodeDeserializeError(String),
+    #[error("There was an error with bitcode's serializing: {0}")]
+    BitcodeSerializeError(String),
     #[error("Chunk not found")]
     ChunkNotFound,
     #[error("Anvil Decode Error: {0}")]

--- a/src/world/format/src/heightmap.rs
+++ b/src/world/format/src/heightmap.rs
@@ -1,19 +1,19 @@
 use crate::errors::WorldError;
 use crate::vanilla_chunk_format::VanillaHeightmaps;
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use temper_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
 use temper_codec::net_types::var_int::VarInt;
 use temper_macros::NetEncode;
 use type_hash::TypeHash;
 
-#[derive(Default, Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Default, Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct Heightmaps {
     pub world_surface: ChunkHeightmap,
     pub motion_blocking: ChunkHeightmap,
 }
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct ChunkHeightmap {
     data: Box<[i16]>,
 }

--- a/src/world/format/src/lib.rs
+++ b/src/world/format/src/lib.rs
@@ -8,7 +8,7 @@ pub mod vanilla_chunk_format;
 
 use crate::errors::WorldError;
 use crate::heightmap::Heightmaps;
-use crate::section::{ChunkSection, AIR};
+use crate::section::{AIR, ChunkSection};
 use deepsize::DeepSizeOf;
 use serde_derive::{Deserialize, Serialize};
 use temper_core::block_state_id::BlockStateId;

--- a/src/world/format/src/lib.rs
+++ b/src/world/format/src/lib.rs
@@ -8,16 +8,16 @@ pub mod vanilla_chunk_format;
 
 use crate::errors::WorldError;
 use crate::heightmap::Heightmaps;
-use crate::section::{AIR, ChunkSection};
-use bitcode_derive::{Decode, Encode};
+use crate::section::{ChunkSection, AIR};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use temper_core::block_state_id::BlockStateId;
 use temper_core::pos::{ChunkBlockPos, ChunkHeight};
 use temper_macros::block;
 use type_hash::TypeHash;
 use vanilla_chunk_format::VanillaChunk;
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct Chunk {
     pub sections: Box<[ChunkSection]>,
     height: ChunkHeight,

--- a/src/world/format/src/light/mod.rs
+++ b/src/world/format/src/light/mod.rs
@@ -1,10 +1,10 @@
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use type_hash::TypeHash;
 
 pub mod network;
 
-#[derive(Default, Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Default, Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub(crate) enum LightStorage {
     #[default]
     Empty,
@@ -14,7 +14,7 @@ pub(crate) enum LightStorage {
     },
 }
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct SectionLightData {
     sky_light: LightStorage,
     block_light: LightStorage,

--- a/src/world/format/src/palette.rs
+++ b/src/world/format/src/palette.rs
@@ -1,6 +1,6 @@
 use crate::section::AIR;
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use std::num::NonZeroU16;
 use temper_core::block_state_id::BlockStateId;
 use type_hash::TypeHash;
@@ -18,7 +18,7 @@ pub enum BlockPaletteResult {
     ConvertToUniform(BlockStateId),
 }
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct BlockPalette {
     pub(crate) palette: Vec<Option<(BlockStateId, NonZeroU16)>>,
     pub(crate) free_count: u16,

--- a/src/world/format/src/section/biome.rs
+++ b/src/world/format/src/section/biome.rs
@@ -1,14 +1,16 @@
-use bitcode_derive::{Decode, Encode};
 use bytemuck::{Pod, Zeroable};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use temper_core::pos::SectionBlockPos;
 use type_hash::TypeHash;
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Encode, Decode, Default, PartialEq, DeepSizeOf, Pod, Zeroable, TypeHash)]
+#[derive(
+    Copy, Clone, Serialize, Deserialize, Default, PartialEq, DeepSizeOf, Pod, Zeroable, TypeHash,
+)]
 pub struct BiomeType(pub u8);
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub enum BiomeData {
     Uniform(BiomeType),
     Mixed(Box<[BiomeType]>),

--- a/src/world/format/src/section/direct.rs
+++ b/src/world/format/src/section/direct.rs
@@ -1,8 +1,8 @@
 use crate::section::paletted::PalettedSection;
 use crate::section::uniform::UniformSection;
 use crate::section::{AIR, CHUNK_SECTION_LENGTH};
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use temper_core::block_state_id::BlockStateId;
 use type_hash::TypeHash;
 
@@ -11,7 +11,7 @@ type CompactBlockStateId = u16;
 
 const AIR_COMPACT: CompactBlockStateId = AIR.raw() as CompactBlockStateId;
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct DirectSection(pub(crate) Box<[CompactBlockStateId]>, u16);
 
 impl Default for DirectSection {

--- a/src/world/format/src/section/mod.rs
+++ b/src/world/format/src/section/mod.rs
@@ -5,8 +5,8 @@ use crate::section::direct::DirectSection;
 use crate::section::paletted::{PalettedSection, PalettedSectionResult};
 use crate::section::uniform::UniformSection;
 use crate::vanilla_chunk_format::Section;
-use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use temper_core::block_state_id::BlockStateId;
 use temper_core::pos::SectionBlockPos;
 use temper_macros::block;
@@ -22,7 +22,7 @@ pub const CHUNK_SECTION_LENGTH: usize = 16 * 16 * 16;
 
 pub(crate) const AIR: BlockStateId = block!("air");
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub(crate) enum ChunkSectionType {
     Uniform(UniformSection),
     Paletted(PalettedSection),
@@ -95,7 +95,7 @@ impl ChunkSectionType {
     }
 }
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct ChunkSection {
     pub(crate) inner: ChunkSectionType,
     pub(crate) light: SectionLightData,

--- a/src/world/format/src/section/paletted.rs
+++ b/src/world/format/src/section/paletted.rs
@@ -1,7 +1,7 @@
+use crate::BlockStateId;
 use crate::palette::{BlockPalette, BlockPaletteResult, PaletteIndex};
 use crate::section::uniform::UniformSection;
 use crate::section::{AIR, CHUNK_SECTION_LENGTH};
-use crate::BlockStateId;
 use deepsize::DeepSizeOf;
 use serde_derive::{Deserialize, Serialize};
 use std::num::NonZeroU16;

--- a/src/world/format/src/section/paletted.rs
+++ b/src/world/format/src/section/paletted.rs
@@ -1,9 +1,9 @@
-use crate::BlockStateId;
 use crate::palette::{BlockPalette, BlockPaletteResult, PaletteIndex};
 use crate::section::uniform::UniformSection;
 use crate::section::{AIR, CHUNK_SECTION_LENGTH};
-use bitcode_derive::{Decode, Encode};
+use crate::BlockStateId;
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use std::num::NonZeroU16;
 use type_hash::TypeHash;
 
@@ -13,7 +13,7 @@ pub enum PalettedSectionResult {
     Shrink(BlockStateId),
 }
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct PalettedSection {
     pub(crate) palette: BlockPalette,
     pub(crate) block_data: Box<[u64]>,

--- a/src/world/format/src/section/uniform.rs
+++ b/src/world/format/src/section/uniform.rs
@@ -1,10 +1,10 @@
-use crate::BlockStateId;
 use crate::section::AIR;
-use bitcode_derive::{Decode, Encode};
+use crate::BlockStateId;
 use deepsize::DeepSizeOf;
+use serde_derive::{Deserialize, Serialize};
 use type_hash::TypeHash;
 
-#[derive(Clone, DeepSizeOf, Encode, Decode, TypeHash)]
+#[derive(Clone, DeepSizeOf, Serialize, Deserialize, TypeHash)]
 pub struct UniformSection(BlockStateId);
 
 impl UniformSection {

--- a/src/world/format/src/section/uniform.rs
+++ b/src/world/format/src/section/uniform.rs
@@ -1,5 +1,5 @@
-use crate::section::AIR;
 use crate::BlockStateId;
+use crate::section::AIR;
 use deepsize::DeepSizeOf;
 use serde_derive::{Deserialize, Serialize};
 use type_hash::TypeHash;

--- a/src/world/src/benches/edit_bench.rs
+++ b/src/world/src/benches/edit_bench.rs
@@ -13,7 +13,7 @@ fn get_rand_in_range(min: i32, max: i32) -> i32 {
 #[expect(clippy::unit_arg)]
 pub(crate) fn bench_edits(c: &mut Criterion) {
     let chunk_data = include_bytes!("../../../../.etc/raw_chunk.dat");
-    let chunk: Chunk = bitcode::decode(chunk_data)
+    let chunk: Chunk = bitcode::deserialize(chunk_data)
         .expect("If this fails, go run the dump_chunk test at src/lib/world/src/mod");
 
     let mut read_group = c.benchmark_group("edit_read");

--- a/src/world/src/lib.rs
+++ b/src/world/src/lib.rs
@@ -175,7 +175,7 @@ mod tests {
                 "Failed to load chunk. If it's a bitcode error, chances are the chunk format \
              has changed since last generating a world so you'll need to regenerate",
             );
-        let encoded = bitcode::encode(&*chunk);
+        let encoded = bitcode::serialize(&*chunk).unwrap();
         std::fs::write("../../../.etc/raw_chunk.dat", encoded).unwrap();
     }
 }


### PR DESCRIPTION
This PR swaps the world format to a serde-based approach for better compatibility with other libraries

## Description
Currently we use bitcode for serialization which works fine, but has the major issue of not working with 3rd party libraries. This means we can't really store any data types that aren't from the standard library or us, so no dashmaps, bevy_math types, etc. This PR swaps it to use serde, but stil using bitcode as the actual serializer. This keeps a good chunk of the speed from bitcode while adding 3rd party lib compatibility.

It is about 3-10x slower, but thats absolutely dwarfed by the compression step so it's not a big deal unless someone invents a compression algorithm that can hit gigabytes of throughput.
The normal bitcode encoder is still used for player data mostly cos I CBA dealing with serde's lifetimes nonsense.

Main reason for all of this is to get started on storing entities.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
World seems to load fine and benchmarks don't crash

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (restructuring code, without changing its behavior)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Clippy passes with no warnings.