### PR TITLE
fix : add openssl in LD path for runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,11 @@
           nativeBuildInputs = [
             rust-toolchain
             pkgs.pkg-config
+          ];
+          buildInputs = [
             pkgs.openssl
           ];
+          LD_LIBRARY_PATH = "${pkgs.openssl.out}/lib";
         };
       };
     };


### PR DESCRIPTION
This PR fix this issues :

```log
error: failed to run custom build command for `temper-dashboard v0.1.0 (/home/tongue/temper/src/dashboard)`

Caused by:
  process didn't exit successfully: `/home/tongue/temper/target/debug/build/temper-dashboard-0cb07f5e1627092c/build-script-build` (exit status: 127)
  --- stderr
  /home/tongue/temper/target/debug/build/temper-dashboard-0cb07f5e1627092c/build-script-build: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
 ```