### PR TITLE
Memory leak fix for messages not being flushed

### DIFF
--- a/src/game_systems/src/lib.rs
+++ b/src/game_systems/src/lib.rs
@@ -125,7 +125,7 @@ fn register_tick_systems(schedule: &mut Schedule) {
     schedule.add_systems(world::particles::handle);
 
     schedule.add_systems(background::bossbar_update::handle);
-    
+
     schedule.add_systems(bevy_ecs::message::message_update_system);
 }
 

--- a/src/game_systems/src/lib.rs
+++ b/src/game_systems/src/lib.rs
@@ -125,6 +125,8 @@ fn register_tick_systems(schedule: &mut Schedule) {
     schedule.add_systems(world::particles::handle);
 
     schedule.add_systems(background::bossbar_update::handle);
+    
+    schedule.add_systems(bevy_ecs::message::message_update_system);
 }
 
 fn register_world_sync_schedule_systems(schedule: &mut Schedule) {


### PR DESCRIPTION
As it turns out we've not been flushing messages this whole time and so have been pissing memory. Cool.