### PR TITLE
feat(time): implement time setting command with enhanced argument

### DIFF
--- a/src/default_commands/src/time.rs
+++ b/src/default_commands/src/time.rs
@@ -30,11 +30,13 @@ fn parse_time_value(s: &str) -> Result<u32, &'static str> {
     }
 
     let last_char = s.chars().last().unwrap();
-    if last_char == 'd' || last_char == 's' || last_char == 't' {
+    if last_char == 's' || last_char == 't'
+    /* || last_char == 'd' */
+    {
         let number_part = &s[..s.len() - 1];
         let val = number_part.parse::<u32>().map_err(|_| "invalid number")?;
         match last_char {
-            'd' => Ok(val * 24000),
+            /* 'd' => Ok(val * 24000), */
             's' => Ok(val * 20),
             't' => Ok(val),
             _ => unreachable!(),
@@ -83,7 +85,7 @@ impl CommandArgument for TimeSetArg {
 
         if !input.is_empty() && input.chars().all(|c| c.is_ascii_digit()) {
             return vec![
-                Suggestion::of(format!("{}d", input)),
+                // Suggestion::of(format!("{}d", input)),
                 Suggestion::of(format!("{}s", input)),
                 Suggestion::of(format!("{}t", input)),
             ];

--- a/src/default_commands/src/time.rs
+++ b/src/default_commands/src/time.rs
@@ -1,38 +1,109 @@
 use bevy_ecs::prelude::{Query, Res, ResMut};
 use temper_commands::arg::primitive::int::Integer;
-use temper_commands::arg::primitive::string::SingleWord;
 use temper_commands::Sender;
 use temper_components::player::time::LastSentTimeUpdate;
 use temper_macros::command;
 use temper_resources::time::WorldTime;
 use temper_text::TextComponent;
 
+use temper_commands::{
+    arg::{primitive::PrimitiveArgument, utils::parser_error, CommandArgument, ParserResult},
+    CommandContext, Suggestion,
+};
+
+#[derive(Debug, Clone, Copy)]
+struct TimeSetArg(u32);
+
+fn parse_time_value(s: &str) -> Result<u32, &'static str> {
+    if s.is_empty() {
+        return Err("empty time value");
+    }
+
+    match s.to_lowercase().as_str() {
+        "day" => return Ok(1000),
+        "noon" => return Ok(6000),
+        "night" => return Ok(13000),
+        "midnight" => return Ok(18000),
+        "dawn" => return Ok(0),
+        "dusk" => return Ok(12000),
+        _ => {}
+    }
+
+    let last_char = s.chars().last().unwrap();
+    if last_char == 'd' || last_char == 's' || last_char == 't' {
+        let number_part = &s[..s.len() - 1];
+        let val = number_part.parse::<u32>().map_err(|_| "invalid number")?;
+        match last_char {
+            'd' => Ok(val * 24000),
+            's' => Ok(val * 20),
+            't' => Ok(val),
+            _ => unreachable!(),
+        }
+    } else {
+        s.parse::<u32>().map_err(|_| "invalid time format")
+    }
+}
+
+impl CommandArgument for TimeSetArg {
+    fn parse(ctx: &mut CommandContext) -> ParserResult<Self> {
+        let s = ctx.input.read_string();
+        match parse_time_value(&s) {
+            Ok(ticks) => Ok(TimeSetArg(ticks)),
+            Err(_) => Err(parser_error(&format!("invalid time value: {}", s))),
+        }
+    }
+
+    fn primitive() -> PrimitiveArgument {
+        PrimitiveArgument::word()
+    }
+
+    fn suggest(ctx: &mut CommandContext) -> Vec<Suggestion> {
+        ctx.input.skip_whitespace(u32::MAX, false);
+        if !ctx.input.has_remaining_input() {
+            return vec![
+                Suggestion::of("day"),
+                Suggestion::of("noon"),
+                Suggestion::of("night"),
+                Suggestion::of("midnight"),
+            ];
+        }
+
+        let input = ctx.input.read_string();
+
+        let presets = ["day", "noon", "night", "midnight", "dawn", "dusk"];
+        let matching_presets: Vec<Suggestion> = presets
+            .into_iter()
+            .filter(|preset| preset.starts_with(&input.to_lowercase()))
+            .map(Suggestion::of)
+            .collect();
+
+        if !matching_presets.is_empty() {
+            return matching_presets;
+        }
+
+        if !input.is_empty() && input.chars().all(|c| c.is_ascii_digit()) {
+            return vec![
+                Suggestion::of(format!("{}d", input)),
+                Suggestion::of(format!("{}s", input)),
+                Suggestion::of(format!("{}t", input)),
+            ];
+        }
+
+        vec![]
+    }
+}
+
 #[command("time set")]
 fn time_set(
     #[sender] sender: Sender,
-    #[arg] time: SingleWord,
+    #[arg] time: TimeSetArg,
     args: (ResMut<WorldTime>, Query<&mut LastSentTimeUpdate>),
 ) {
     let (mut world_time, mut query) = args;
 
-    match time.parse::<u16>() {
-        Ok(time) => world_time.set_time(time),
-        Err(_) => match time.as_str() {
-            "day" => world_time.set_time_to_start(WorldTime::DAY),
-            "dawn" => world_time.set_time_to_start(WorldTime::DAWN),
-            "night" => world_time.set_time_to_start(WorldTime::NIGHT),
-            "dusk" => world_time.set_time_to_start(WorldTime::DUSK),
-
-            "noon" | "midday" => world_time.set_time_to_middle(WorldTime::DAY),
-            "midnight" => world_time.set_time_to_middle(WorldTime::NIGHT),
-
-            time => {
-                sender.send_message(TextComponent::from(format!("Unknown time '{time}'")), false);
-
-                return;
-            }
-        },
-    }
+    let ticks = time.0;
+    let ticks_u16 = (ticks % 24000) as u16;
+    world_time.set_time(ticks_u16);
 
     sender.send_message(
         TextComponent::from(format!(


### PR DESCRIPTION
This pull request refactors the `time set` command to support more flexible and user-friendly time input formats, replacing the previous string-based parsing with a custom argument type. It introduces parsing for both named times (like "noon", "night") and numeric formats with optional suffixes, and adds intelligent suggestions for tab-completion.

### Command argument improvements

* Added a new `TimeSetArg` struct implementing `CommandArgument`, allowing the `time set` command to accept named times (e.g., "dawn", "noon"), numbers, and numbers with suffixes (`d`, `s`, `t`) for days, seconds, and ticks, respectively. This replaces the previous use of `SingleWord` and manual string matching.
* Implemented the `parse_time_value` function to handle parsing of named times and suffixed numeric values, improving input flexibility and robustness.

### Command suggestion enhancements

* Enhanced tab-completion suggestions for the `time set` command, including named presets and dynamic suggestions for numeric input with suffixes, making the command more user-friendly.

### Code simplification

* Simplified the `time_set` command handler by removing manual string matching logic and using the parsed tick value directly.

<img width="384" height="283" alt="image" src="https://github.com/user-attachments/assets/7c489933-e48e-48e6-a0d4-5cead3738bde" />
<img width="282" height="211" alt="image" src="https://github.com/user-attachments/assets/a3cff8a6-0157-4026-a297-70703f437a47" />
