### PR TITLE
build(dashboard): implement caching for dashboard downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TEMPER_FORCE_DASHBOARD_DOWNLOAD: "1"
 
 defaults:
   run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  TEMPER_FORCE_DASHBOARD_DOWNLOAD: "1"
 
 defaults:
   run:

--- a/src/dashboard/build.rs
+++ b/src/dashboard/build.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
     // 2. Check cache age to avoid downloading on every single compile.
     let force_download = env::var("TEMPER_FORCE_DASHBOARD_DOWNLOAD").is_ok();
     let index_html = dest_dir.join("index.html");
-    
+
     let has_recent_dashboard = if index_html.exists() {
         if let Ok(metadata) = fs::metadata(&index_html) {
             if let Ok(modified) = metadata.modified() {
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
 
     if should_download {
         println!(
-            "Downloading Dashboard artifact from {}",
+            "cargo:warning=Downloading Dashboard artifact from {}",
             DASHBOARD_URL
         );
 
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
                     }
                 }
 
-                println!("Dashboard extracted to {:?}", dest_dir);
+                println!("cargo:warning=Dashboard extracted to {:?}", dest_dir);
             }
             _ => {
                 // Download failed (no internet, request error, non-success status)
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
         }
     } else {
         println!(
-            "Using cached Dashboard (last downloaded <24h ago). Set TEMPER_FORCE_DASHBOARD_DOWNLOAD=1 to force update."
+            "cargo:warning=Using cached Dashboard (last downloaded <24h ago). Set TEMPER_FORCE_DASHBOARD_DOWNLOAD=1 to force update."
         );
     }
 

--- a/src/dashboard/build.rs
+++ b/src/dashboard/build.rs
@@ -43,7 +43,9 @@ fn main() -> Result<()> {
     }
 
     // 2. Check cache age to avoid downloading on every single compile.
-    let force_download = env::var("TEMPER_FORCE_DASHBOARD_DOWNLOAD").is_ok();
+    let force_download = env::var("TEMPER_FORCE_DASHBOARD_DOWNLOAD")
+        .map(|v| v == "1")
+        .unwrap_or(false);
     let index_html = dest_dir.join("index.html");
 
     let has_recent_dashboard = 'check: {
@@ -67,7 +69,9 @@ fn main() -> Result<()> {
             DASHBOARD_URL
         );
 
-        let client = reqwest::blocking::Client::new();
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
         let download_result = client
             .get(DASHBOARD_URL)
             .header("User-Agent", "temper-build-script")

--- a/src/dashboard/build.rs
+++ b/src/dashboard/build.rs
@@ -47,9 +47,15 @@ fn main() -> Result<()> {
     let index_html = dest_dir.join("index.html");
 
     let has_recent_dashboard = 'check: {
-        let Ok(metadata) = fs::metadata(&index_html) else { break 'check false };
-        let Ok(modified) = metadata.modified() else { break 'check false };
-        let Ok(elapsed) = SystemTime::now().duration_since(modified) else { break 'check false };
+        let Ok(metadata) = fs::metadata(&index_html) else {
+            break 'check false;
+        };
+        let Ok(modified) = metadata.modified() else {
+            break 'check false;
+        };
+        let Ok(elapsed) = SystemTime::now().duration_since(modified) else {
+            break 'check false;
+        };
         elapsed.as_secs() < 86_400
     };
 

--- a/src/dashboard/build.rs
+++ b/src/dashboard/build.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs;
 use std::io::{Cursor, Write};
 use std::path::Path;
+use std::time::SystemTime;
 use zip::ZipArchive;
 
 // CONFIGURATION
@@ -15,6 +16,9 @@ fn main() -> Result<()> {
     println!("cargo::rustc-check-cfg=cfg(dashboard_in_out_dir)");
     println!("cargo::rustc-check-cfg=cfg(dashboard_in_manifest_dir)");
     println!("cargo::rustc-check-cfg=cfg(dashboard_build)");
+
+    // Rerun if the force download environment variable changes
+    println!("cargo:rerun-if-env-changed=TEMPER_FORCE_DASHBOARD_DOWNLOAD");
 
     // 1. Determine where to put the files.
     let (dest_dir, use_out_dir) = if let Ok(out_dir) = env::var("OUT_DIR") {
@@ -38,67 +42,97 @@ fn main() -> Result<()> {
         println!("cargo:rustc-cfg=dashboard_in_manifest_dir");
     }
 
-    // 2. Always attempt to download the dashboard
-    println!(
-        "cargo:warning=Downloading Dashboard artifact from {}",
-        DASHBOARD_URL
-    );
-
-    let client = reqwest::blocking::Client::new();
-    let download_result = client
-        .get(DASHBOARD_URL)
-        .header("User-Agent", "temper-build-script")
-        .send();
-
-    match download_result {
-        Ok(response) if response.status().is_success() => {
-            // Delete existing directory if it exists
-            if dest_dir.exists() {
-                fs::remove_dir_all(&dest_dir)?;
-            }
-
-            let content = response.bytes()?;
-
-            // Extract the zip file
-            let cursor = Cursor::new(content);
-            let mut archive = ZipArchive::new(cursor)?;
-
-            // Create the destination directory
-            fs::create_dir_all(&dest_dir)?;
-
-            // Extract all files
-            for i in 0..archive.len() {
-                let mut file = archive.by_index(i)?;
-                let outpath = dest_dir.join(file.mangled_name()?);
-
-                if file.is_dir() {
-                    fs::create_dir_all(&outpath)?;
+    // 2. Check cache age to avoid downloading on every single compile.
+    let force_download = env::var("TEMPER_FORCE_DASHBOARD_DOWNLOAD").is_ok();
+    let index_html = dest_dir.join("index.html");
+    
+    let has_recent_dashboard = if index_html.exists() {
+        if let Ok(metadata) = fs::metadata(&index_html) {
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(elapsed) = SystemTime::now().duration_since(modified) {
+                    // Cache threshold: 24 hours (86,400 seconds)
+                    elapsed.as_secs() < 86400
                 } else {
-                    if let Some(parent) = outpath.parent() {
-                        fs::create_dir_all(parent)?;
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    let should_download = force_download || !has_recent_dashboard;
+
+    if should_download {
+        println!(
+            "Downloading Dashboard artifact from {}",
+            DASHBOARD_URL
+        );
+
+        let client = reqwest::blocking::Client::new();
+        let download_result = client
+            .get(DASHBOARD_URL)
+            .header("User-Agent", "temper-build-script")
+            .send();
+
+        match download_result {
+            Ok(response) if response.status().is_success() => {
+                // Delete existing directory if it exists
+                if dest_dir.exists() {
+                    fs::remove_dir_all(&dest_dir)?;
+                }
+
+                let content = response.bytes()?;
+
+                // Extract the zip file
+                let cursor = Cursor::new(content);
+                let mut archive = ZipArchive::new(cursor)?;
+
+                // Create the destination directory
+                fs::create_dir_all(&dest_dir)?;
+
+                // Extract all files
+                for i in 0..archive.len() {
+                    let mut file = archive.by_index(i)?;
+                    let outpath = dest_dir.join(file.mangled_name()?);
+
+                    if file.is_dir() {
+                        fs::create_dir_all(&outpath)?;
+                    } else {
+                        if let Some(parent) = outpath.parent() {
+                            fs::create_dir_all(parent)?;
+                        }
+                        let mut outfile = fs::File::create(&outpath)?;
+                        std::io::copy(&mut file, &mut outfile)?;
                     }
-                    let mut outfile = fs::File::create(&outpath)?;
-                    std::io::copy(&mut file, &mut outfile)?;
+                }
+
+                println!("Dashboard extracted to {:?}", dest_dir);
+            }
+            _ => {
+                // Download failed (no internet, request error, non-success status)
+                if dest_dir.exists() {
+                    // Use existing dashboard files
+                    println!("cargo:warning=Download failed, using existing dashboard files.");
+                } else {
+                    // Create fallback HTML
+                    println!(
+                        "cargo:warning=Download failed and no existing dashboard. Creating fallback."
+                    );
+                    fs::create_dir_all(&dest_dir)?;
+                    let mut file = fs::File::create(dest_dir.join("index.html"))?;
+                    file.write_all(b"<h1>Dashboard Offline (Build failed to fetch)</h1>")?;
                 }
             }
-
-            println!("cargo:warning=Dashboard extracted to {:?}", dest_dir);
         }
-        _ => {
-            // Download failed (no internet, request error, non-success status)
-            if dest_dir.exists() {
-                // Use existing dashboard files
-                println!("cargo:warning=Download failed, using existing dashboard files.");
-            } else {
-                // Create fallback HTML
-                println!(
-                    "cargo:warning=Download failed and no existing dashboard. Creating fallback."
-                );
-                fs::create_dir_all(&dest_dir)?;
-                let mut file = fs::File::create(dest_dir.join("index.html"))?;
-                file.write_all(b"<h1>Dashboard Offline (Build failed to fetch)</h1>")?;
-            }
-        }
+    } else {
+        println!(
+            "Using cached Dashboard (last downloaded <24h ago). Set TEMPER_FORCE_DASHBOARD_DOWNLOAD=1 to force update."
+        );
     }
 
     // Emit a cfg flag so the main code knows build.rs ran

--- a/src/dashboard/build.rs
+++ b/src/dashboard/build.rs
@@ -46,23 +46,11 @@ fn main() -> Result<()> {
     let force_download = env::var("TEMPER_FORCE_DASHBOARD_DOWNLOAD").is_ok();
     let index_html = dest_dir.join("index.html");
 
-    let has_recent_dashboard = if index_html.exists() {
-        if let Ok(metadata) = fs::metadata(&index_html) {
-            if let Ok(modified) = metadata.modified() {
-                if let Ok(elapsed) = SystemTime::now().duration_since(modified) {
-                    // Cache threshold: 24 hours (86,400 seconds)
-                    elapsed.as_secs() < 86400
-                } else {
-                    false
-                }
-            } else {
-                false
-            }
-        } else {
-            false
-        }
-    } else {
-        false
+    let has_recent_dashboard = 'check: {
+        let Ok(metadata) = fs::metadata(&index_html) else { break 'check false };
+        let Ok(modified) = metadata.modified() else { break 'check false };
+        let Ok(elapsed) = SystemTime::now().duration_since(modified) else { break 'check false };
+        elapsed.as_secs() < 86_400
     };
 
     let should_download = force_download || !has_recent_dashboard;
@@ -102,13 +90,13 @@ fn main() -> Result<()> {
 
                     if file.is_dir() {
                         fs::create_dir_all(&outpath)?;
-                    } else {
-                        if let Some(parent) = outpath.parent() {
-                            fs::create_dir_all(parent)?;
-                        }
-                        let mut outfile = fs::File::create(&outpath)?;
-                        std::io::copy(&mut file, &mut outfile)?;
+                        continue;
                     }
+                    if let Some(parent) = outpath.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    let mut outfile = fs::File::create(&outpath)?;
+                    std::io::copy(&mut file, &mut outfile)?;
                 }
 
                 println!("cargo:warning=Dashboard extracted to {:?}", dest_dir);


### PR DESCRIPTION
This pull request improves the build process for the dashboard by introducing a caching mechanism to avoid unnecessary downloads. The build script now checks the age of the cached dashboard and only downloads a new copy if the cache is older than 24 hours or if explicitly forced by an environment variable. This should speed up builds and reduce redundant network usage.

**Dashboard download caching:**

* Added logic to check the modification time of the cached `index.html` file and only download the dashboard if it is older than 24 hours.
* Introduced the `TEMPER_FORCE_DASHBOARD_DOWNLOAD` environment variable to force a dashboard download regardless of cache age. [[1]](diffhunk://#diff-e96d08dff1e79e1239fbda8ee971b3c8f91fad475223f80238d8aee62d1d9151R20-R22) [[2]](diffhunk://#diff-e96d08dff1e79e1239fbda8ee971b3c8f91fad475223f80238d8aee62d1d9151L41-R72)
* Added a message indicating when the cached dashboard is used and instructions to force an update.

**Other improvements:**

* Changed warning messages to regular informational messages for dashboard download and extraction to reduce build noise.
* Added `std::time::SystemTime` import to support cache age checking.

```bash
cargo run
warning: /home/cleboost/Code/temper/src/config/Cargo.toml: version requirement `1.1.2+spec-1.1.0` for dependency `toml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
    Blocking waiting for file lock on artifact directory
   Compiling libc v0.2.186
   Compiling cfg-if v1.0.4
   Compiling pin-project-lite v0.2.17
	... (clear for size)
   Compiling memchr v2.8.0
   Compiling bin-runtime v0.1.0 (/home/cleboost/Code/temper/src/app/runtime)
   Compiling temper-app v0.1.1 (/home/cleboost/Code/temper/src/app)
   Compiling temper v0.1.1 (/home/cleboost/Code/temper/src/bin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 22s
     Running `target/debug/temper`

touch src/dashboard/build.rs # Need touch for demo because cargo use his "replay" for console so we can't se cache (but it's been applied)

cargo run
warning: /home/cleboost/Code/temper/src/config/Cargo.toml: version requirement `1.1.2+spec-1.1.0` for dependency `toml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
   Compiling temper-dashboard v0.1.0 (/home/cleboost/Code/temper/src/dashboard)
warning: temper-dashboard@0.1.0: Using cached Dashboard (last downloaded <24h ago). Set TEMPER_FORCE_DASHBOARD_DOWNLOAD=1 to force update.
   Compiling bin-runtime v0.1.0 (/home/cleboost/Code/temper/src/app/runtime)
   Compiling temper-app v0.1.1 (/home/cleboost/Code/temper/src/app)
   Compiling temper v0.1.1 (/home/cleboost/Code/temper/src/bin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.42s
     Running `target/debug/temper`
```

fix https://github.com/temper-mc/temper/issues/29