### PR TITLE
Make EntityArgument suggestions case-insensitive and functional

### DIFF
--- a/src/commands/src/arg/entities/mod.rs
+++ b/src/commands/src/arg/entities/mod.rs
@@ -67,6 +67,7 @@ impl CommandArgument for EntityArgument {
     }
 
     fn suggest(ctx: &mut CommandContext) -> Vec<Suggestion> {
+        ctx.input.read_string();
         let mut suggestions = vec![
             Suggestion {
                 content: "@e".to_string(),
@@ -231,6 +232,27 @@ mod tests {
             arg,
             EntityArgument::Uuid(Uuid::parse_str(uuid_str).unwrap())
         );
+    }
+
+    #[test]
+    fn test_suggest_entity_argument() {
+        let mut ctx = CommandContext {
+            input: CommandInput {
+                input: "a".to_string(),
+                cursor: 0,
+            },
+            command: Arc::new(Command {
+                name: "",
+                args: vec![],
+            }),
+            sender: Sender::Server,
+            state: create_test_state().0.0,
+        };
+        let suggestions = EntityArgument::suggest(&mut ctx);
+        assert!(!ctx.input.has_remaining_input());
+        assert!(suggestions.iter().any(|s| s.content == "@a"));
+        assert!(suggestions.iter().any(|s| s.content == "@e"));
+        assert!(suggestions.iter().any(|s| s.content == "@r"));
     }
 
     #[test]

--- a/src/game_systems/src/packets/src/command_suggestions.rs
+++ b/src/game_systems/src/packets/src/command_suggestions.rs
@@ -122,7 +122,11 @@ pub fn handle(
                 matches: LengthPrefixedVec::new(
                     suggestions
                         .into_iter()
-                        .filter(|sug| sug.content.starts_with(current_token))
+                        .filter(|sug| {
+                            sug.content
+                                .to_lowercase()
+                                .starts_with(&current_token.to_lowercase())
+                        })
                         .map(|sug| Match {
                             content: sug.content,
                             tooltip: PrefixedOptional::new(sug.tooltip),


### PR DESCRIPTION
This pull request improves the entity argument suggestion system and enhances the user experience when requesting command suggestions. The main changes include making suggestion matching case-insensitive, ensuring the input is fully read before generating suggestions, and adding a unit test to verify the new behavior.

### Suggestion system improvements

* Suggestion matching is now case-insensitive, so suggestions will match user input regardless of letter case (`src/game_systems/src/packets/src/command_suggestions.rs`).
* The `suggest` method for `EntityArgument` now reads the entire input string before generating suggestions, ensuring that the input is fully consumed and suggestions are accurate (`src/commands/src/arg/entities/mod.rs`).

### Testing

* Added a unit test `test_suggest_entity_argument` to verify that suggestions include `@a`, `@e`, and `@r`, and to check that the input is fully consumed after suggestion generation (`src/commands/src/arg/entities/mod.rs`).