### PR TITLE
fix: lmdb optimizations

### DIFF
--- a/src/app/runtime/src/setup.rs
+++ b/src/app/runtime/src/setup.rs
@@ -57,15 +57,17 @@ pub fn generate_spawn_chunks(state: GlobalState) -> Result<(), BinaryError> {
 pub fn setup_db(state: GlobalState) -> Result<(), BinaryError> {
     info!("Setting up database...");
 
+    state.world.storage_backend.create_table("metadata")?;
+
     let chunk_key = string_to_u128("chunk-format-hash");
-    state.world.storage_backend.insert(
+    state.world.storage_backend.upsert(
         "metadata",
         chunk_key,
         Chunk::type_hash().to_be_bytes().to_vec(),
     )?;
 
     let player_key = string_to_u128("player-format-hash");
-    state.world.storage_backend.insert(
+    state.world.storage_backend.upsert(
         "metadata",
         player_key,
         OfflinePlayerData::type_hash().to_be_bytes().to_vec(),

--- a/src/app/runtime/src/setup.rs
+++ b/src/app/runtime/src/setup.rs
@@ -59,14 +59,14 @@ pub fn setup_db(state: GlobalState) -> Result<(), BinaryError> {
 
     let chunk_key = string_to_u128("chunk-format-hash");
     state.world.storage_backend.insert(
-        "metadata".to_string(),
+        "metadata",
         chunk_key,
         Chunk::type_hash().to_be_bytes().to_vec(),
     )?;
 
     let player_key = string_to_u128("player-format-hash");
     state.world.storage_backend.insert(
-        "metadata".to_string(),
+        "metadata",
         player_key,
         OfflinePlayerData::type_hash().to_be_bytes().to_vec(),
     )?;

--- a/src/app/validate/src/check_chunks.rs
+++ b/src/app/validate/src/check_chunks.rs
@@ -10,7 +10,7 @@ use tracing::{error, warn};
 use type_hash::TypeHash;
 
 pub fn check_chunks(state: &ServerState) -> Result<(), String> {
-    let env = state.world.storage_backend.env.lock();
+    let env = &state.world.storage_backend.env;
     let txn = env
         .read_txn()
         .map_err(|e| format!("Failed to create read transaction: {}", e))?;

--- a/src/app/validate/src/check_players.rs
+++ b/src/app/validate/src/check_players.rs
@@ -10,7 +10,7 @@ use type_hash::TypeHash;
 use uuid::Uuid;
 
 pub fn check_players(state: &ServerState) -> Result<(), String> {
-    let env = state.world.storage_backend.env.lock();
+    let env = &state.world.storage_backend.env;
     let txn = env
         .read_txn()
         .map_err(|e| format!("Failed to create read transaction: {}", e))?;

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -17,6 +17,7 @@ criterion = { workspace = true }
 tempfile = { workspace = true }
 wyhash = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 
 [[bench]]
 name = "storage_bench"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 thiserror = { workspace = true }
 heed = { workspace = true }
 page_size = { workspace = true }
+dashmap = { workspace = true }
 parking_lot = { workspace = true }
 
 

--- a/src/storage/src/benches/db.rs
+++ b/src/storage/src/benches/db.rs
@@ -107,8 +107,6 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     read_group.finish();
 
-    let mut concurrent_group = c.benchmark_group("ConcurrentRead");
-
     db.create_table("concurrent_test").unwrap();
 
     let concurrent_keys: Vec<u128> = (0..1000)
@@ -121,27 +119,31 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     let db = Arc::new(db);
 
+    let mut pool_group = c.benchmark_group("ConcurrentReadPool");
+
     for thread_count in [2usize, 4, 8, 16] {
         let db = Arc::clone(&db);
         let keys = concurrent_keys.clone();
 
-        concurrent_group.bench_function(format!("{thread_count}_threads_512b"), |b| {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(thread_count)
+            .build()
+            .unwrap();
+
+        pool_group.bench_function(format!("{thread_count}_threads_512b"), |b| {
             b.iter(|| {
-                let handles: Vec<_> = (0..thread_count)
-                    .map(|_| {
+                pool.scope(|s| {
+                    for _ in 0..thread_count {
                         let db = Arc::clone(&db);
                         let keys = keys.clone();
-                        std::thread::spawn(move || {
+                        s.spawn(move |_| {
                             db.get("concurrent_test", select_random(&keys)).unwrap();
-                        })
-                    })
-                    .collect();
-                for h in handles {
-                    h.join().unwrap();
-                }
+                        });
+                    }
+                });
             })
         });
     }
 
-    concurrent_group.finish();
+    pool_group.finish();
 }

--- a/src/storage/src/benches/db.rs
+++ b/src/storage/src/benches/db.rs
@@ -28,14 +28,14 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     let db = StorageBackend::initialize(Some(tempdir), 100 * 1024 * 1024 * 1024).unwrap();
 
-    db.create_table("insert_test".to_string()).unwrap();
+    db.create_table("insert_test").unwrap();
 
     let mut insert_group = c.benchmark_group("Insert");
 
     insert_group.bench_function("512b".to_string(), |b| {
         b.iter(|| {
             db.insert(
-                "insert_test".to_string(),
+                "insert_test",
                 generate_random_key(&mut used_keys),
                 generate_random_data(512),
             )
@@ -46,7 +46,7 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
     insert_group.bench_function("1kb".to_string(), |b| {
         b.iter(|| {
             db.insert(
-                "insert_test".to_string(),
+                "insert_test",
                 generate_random_key(&mut used_keys),
                 generate_random_data(1024),
             )
@@ -57,7 +57,7 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
     insert_group.bench_function("4kb".to_string(), |b| {
         b.iter(|| {
             db.insert(
-                "insert_test".to_string(),
+                "insert_test",
                 generate_random_key(&mut used_keys),
                 generate_random_data(4096),
             )
@@ -69,20 +69,20 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     let mut read_group = c.benchmark_group("Read");
 
-    db.create_table("read_test".to_string()).unwrap();
+    db.create_table("read_test").unwrap();
 
     let keys_512b = (0..1000)
         .map(|_| generate_random_key(&mut used_keys))
         .collect::<Vec<_>>();
 
     for key in keys_512b.iter() {
-        db.insert("read_test".to_string(), *key, generate_random_data(512))
+        db.insert("read_test", *key, generate_random_data(512))
             .unwrap();
     }
 
     read_group.bench_function("512b".to_string(), |b| {
         b.iter(|| {
-            db.get("read_test".to_string(), select_random(keys_512b.clone()))
+            db.get("read_test", select_random(keys_512b.clone()))
                 .unwrap();
         })
     });
@@ -92,13 +92,13 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
         .collect::<Vec<_>>();
 
     for key in keys_1kb.iter() {
-        db.insert("read_test".to_string(), *key, generate_random_data(1024))
+        db.insert("read_test", *key, generate_random_data(1024))
             .unwrap();
     }
 
     read_group.bench_function("1kb".to_string(), |b| {
         b.iter(|| {
-            db.get("read_test".to_string(), select_random(keys_1kb.clone()))
+            db.get("read_test", select_random(keys_1kb.clone()))
                 .unwrap();
         })
     });
@@ -108,13 +108,13 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
         .collect::<Vec<_>>();
 
     for key in keys_4kb.iter() {
-        db.insert("read_test".to_string(), *key, generate_random_data(4096))
+        db.insert("read_test", *key, generate_random_data(4096))
             .unwrap();
     }
 
     read_group.bench_function("4kb".to_string(), |b| {
         b.iter(|| {
-            db.get("read_test".to_string(), select_random(keys_4kb.clone()))
+            db.get("read_test", select_random(keys_4kb.clone()))
                 .unwrap();
         })
     });

--- a/src/storage/src/benches/db.rs
+++ b/src/storage/src/benches/db.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 use temper_storage::lmdb::StorageBackend;
 
 fn generate_random_data(size: usize) -> Vec<u8> {
@@ -17,9 +18,9 @@ fn generate_random_key(used: &mut HashSet<u128>) -> u128 {
     key
 }
 
-fn select_random<T: Clone + Copy>(choices: Vec<T>) -> T {
+fn select_random<T: Clone + Copy>(choices: &[T]) -> T {
     let index = rand::random::<u32>() as usize % choices.len();
-    *choices.get(index).unwrap()
+    choices[index]
 }
 
 pub(crate) fn db_benches(c: &mut criterion::Criterion) {
@@ -32,7 +33,7 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     let mut insert_group = c.benchmark_group("Insert");
 
-    insert_group.bench_function("512b".to_string(), |b| {
+    insert_group.bench_function("512b", |b| {
         b.iter(|| {
             db.insert(
                 "insert_test",
@@ -43,7 +44,7 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
         })
     });
 
-    insert_group.bench_function("1kb".to_string(), |b| {
+    insert_group.bench_function("1kb", |b| {
         b.iter(|| {
             db.insert(
                 "insert_test",
@@ -54,7 +55,7 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
         })
     });
 
-    insert_group.bench_function("4kb".to_string(), |b| {
+    insert_group.bench_function("4kb", |b| {
         b.iter(|| {
             db.insert(
                 "insert_test",
@@ -71,53 +72,76 @@ pub(crate) fn db_benches(c: &mut criterion::Criterion) {
 
     db.create_table("read_test").unwrap();
 
-    let keys_512b = (0..1000)
+    let keys_512b: Vec<u128> = (0..1000)
         .map(|_| generate_random_key(&mut used_keys))
-        .collect::<Vec<_>>();
-
+        .collect();
     for key in keys_512b.iter() {
         db.insert("read_test", *key, generate_random_data(512))
             .unwrap();
     }
-
-    read_group.bench_function("512b".to_string(), |b| {
-        b.iter(|| {
-            db.get("read_test", select_random(keys_512b.clone()))
-                .unwrap();
-        })
+    read_group.bench_function("512b", |b| {
+        b.iter(|| db.get("read_test", select_random(&keys_512b)).unwrap())
     });
 
-    let keys_1kb = (0..1000)
+    let keys_1kb: Vec<u128> = (0..1000)
         .map(|_| generate_random_key(&mut used_keys))
-        .collect::<Vec<_>>();
-
+        .collect();
     for key in keys_1kb.iter() {
         db.insert("read_test", *key, generate_random_data(1024))
             .unwrap();
     }
-
-    read_group.bench_function("1kb".to_string(), |b| {
-        b.iter(|| {
-            db.get("read_test", select_random(keys_1kb.clone()))
-                .unwrap();
-        })
+    read_group.bench_function("1kb", |b| {
+        b.iter(|| db.get("read_test", select_random(&keys_1kb)).unwrap())
     });
 
-    let keys_4kb = (0..1000)
+    let keys_4kb: Vec<u128> = (0..1000)
         .map(|_| generate_random_key(&mut used_keys))
-        .collect::<Vec<_>>();
-
+        .collect();
     for key in keys_4kb.iter() {
         db.insert("read_test", *key, generate_random_data(4096))
             .unwrap();
     }
-
-    read_group.bench_function("4kb".to_string(), |b| {
-        b.iter(|| {
-            db.get("read_test", select_random(keys_4kb.clone()))
-                .unwrap();
-        })
+    read_group.bench_function("4kb", |b| {
+        b.iter(|| db.get("read_test", select_random(&keys_4kb)).unwrap())
     });
 
     read_group.finish();
+
+    let mut concurrent_group = c.benchmark_group("ConcurrentRead");
+
+    db.create_table("concurrent_test").unwrap();
+
+    let concurrent_keys: Vec<u128> = (0..1000)
+        .map(|_| generate_random_key(&mut used_keys))
+        .collect();
+    for key in concurrent_keys.iter() {
+        db.insert("concurrent_test", *key, generate_random_data(512))
+            .unwrap();
+    }
+
+    let db = Arc::new(db);
+
+    for thread_count in [2usize, 4, 8, 16] {
+        let db = Arc::clone(&db);
+        let keys = concurrent_keys.clone();
+
+        concurrent_group.bench_function(format!("{thread_count}_threads_512b"), |b| {
+            b.iter(|| {
+                let handles: Vec<_> = (0..thread_count)
+                    .map(|_| {
+                        let db = Arc::clone(&db);
+                        let keys = keys.clone();
+                        std::thread::spawn(move || {
+                            db.get("concurrent_test", select_random(&keys)).unwrap();
+                        })
+                    })
+                    .collect();
+                for h in handles {
+                    h.join().unwrap();
+                }
+            })
+        });
+    }
+
+    concurrent_group.finish();
 }

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -1,14 +1,18 @@
 use crate::errors::StorageError;
+use dashmap::DashMap;
 use heed;
 use heed::byteorder::BigEndian;
 use heed::types::{Bytes, U128};
 use heed::{Database, Env, EnvOpenOptions, WithoutTls};
+use parking_lot::Mutex;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct StorageBackend {
     pub env: Arc<Env<WithoutTls>>,
+    dbs: Arc<DashMap<String, Database<U128<BigEndian>, Bytes>>>,
+    dbi_open_lock: Arc<parking_lot::Mutex<()>>,
 }
 
 impl From<heed::Error> for StorageError {
@@ -46,6 +50,8 @@ impl StorageBackend {
                         .open(checked_path)
                         .map_err(|e| StorageError::DatabaseInitError(e.to_string()))?,
                 ),
+                dbs: Arc::new(DashMap::new()),
+                dbi_open_lock: Arc::new(parking_lot::Mutex::new(())),
             };
             Ok(backend)
         }
@@ -53,8 +59,7 @@ impl StorageBackend {
 
     pub fn insert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
         let mut rw_txn = self.env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> =
-            self.env.create_database(&mut rw_txn, Some(table))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         if db.get_or_put(&mut rw_txn, &key, &value)?.is_some() {
             return Err(StorageError::KeyExists(key as u64));
         }
@@ -64,19 +69,13 @@ impl StorageBackend {
 
     pub fn get(&self, table: &str, key: u128) -> Result<Option<Vec<u8>>, StorageError> {
         let ro_txn = self.env.read_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = self
-            .env
-            .open_database(&ro_txn, Some(table))?
-            .ok_or(StorageError::TableError("Table not found".to_string()))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         Ok(db.get(&ro_txn, &key)?.map(|v| v.to_vec()))
     }
 
     pub fn delete(&self, table: &str, key: u128) -> Result<(), StorageError> {
         let mut rw_txn = self.env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = self
-            .env
-            .open_database(&rw_txn, Some(table))?
-            .ok_or(StorageError::TableError("Table not found".to_string()))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         if !db.delete(&mut rw_txn, &key)? {
             return Err(StorageError::KeyNotFound(key as u64));
         }
@@ -86,10 +85,7 @@ impl StorageBackend {
 
     pub fn update(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
         let mut rw_txn = self.env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = self
-            .env
-            .open_database(&rw_txn, Some(table))?
-            .ok_or(StorageError::TableError("Table not found".to_string()))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         if db.get(&rw_txn, &key)?.is_none() {
             return Err(StorageError::KeyNotFound(key as u64));
         }
@@ -100,10 +96,7 @@ impl StorageBackend {
 
     pub fn upsert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<bool, StorageError> {
         let mut rw_txn = self.env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = self
-            .env
-            .open_database(&rw_txn, Some(table))?
-            .ok_or(StorageError::TableError("Table not found".to_string()))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         db.put(&mut rw_txn, &key, &value)?;
         rw_txn.commit()?;
         Ok(true)
@@ -111,19 +104,12 @@ impl StorageBackend {
 
     pub fn exists(&self, table: &str, key: u128) -> Result<bool, StorageError> {
         let ro_txn = self.env.read_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = self
-            .env
-            .open_database(&ro_txn, Some(table))?
-            .ok_or(StorageError::TableError("Table not found".to_string()))?;
+        let db: Database<U128<BigEndian>, Bytes> = self.get_db(table)?;
         Ok(db.get(&ro_txn, &key)?.is_some())
     }
 
     pub fn table_exists(&self, table: &str) -> Result<bool, StorageError> {
-        let ro_txn = self.env.read_txn()?;
-        let db = self
-            .env
-            .open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?;
-        Ok(db.is_some())
+        Ok(self.dbs.contains_key(table))
     }
 
     pub fn details(&self) -> String {
@@ -138,9 +124,11 @@ impl StorageBackend {
 
     pub fn create_table(&self, table: &str) -> Result<(), StorageError> {
         let mut rw_txn = self.env.write_txn()?;
-        self.env
+        let db = self
+            .env
             .create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(table))?;
         rw_txn.commit()?;
+        self.dbs.insert(table.to_string(), db);
         Ok(())
     }
 
@@ -151,6 +139,26 @@ impl StorageBackend {
 
     pub fn get_env(&self) -> Arc<Env<WithoutTls>> {
         self.env.clone()
+    }
+
+    fn get_db(&self, table: &str) -> Result<Database<U128<BigEndian>, Bytes>, StorageError> {
+        // Already in cache
+        if let Some(db) = self.dbs.get(table) {
+            return Ok(*db);
+        }
+        // First time
+        let _lock = self.dbi_open_lock.lock();
+        // Double-check
+        if let Some(db) = self.dbs.get(table) {
+            return Ok(*db);
+        }
+        let ro_txn = self.env.read_txn()?;
+        let db = self
+            .env
+            .open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?
+            .ok_or_else(|| StorageError::TableError("Table not found".to_string()))?;
+        self.dbs.insert(table.to_string(), db);
+        Ok(db)
     }
 }
 

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -52,7 +52,7 @@ impl StorageBackend {
         }
     }
 
-    pub fn insert(&self, table: String, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
+    pub fn insert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> =
@@ -64,7 +64,7 @@ impl StorageBackend {
         Ok(())
     }
 
-    pub fn get(&self, table: String, key: u128) -> Result<Option<Vec<u8>>, StorageError> {
+    pub fn get(&self, table: &str, key: u128) -> Result<Option<Vec<u8>>, StorageError> {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
@@ -73,7 +73,7 @@ impl StorageBackend {
         Ok(db.get(&ro_txn, &key)?.map(|v| v.to_vec()))
     }
 
-    pub fn delete(&self, table: String, key: u128) -> Result<(), StorageError> {
+    pub fn delete(&self, table: &str, key: u128) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
@@ -86,7 +86,7 @@ impl StorageBackend {
         Ok(())
     }
 
-    pub fn update(&self, table: String, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
+    pub fn update(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
@@ -100,7 +100,7 @@ impl StorageBackend {
         Ok(())
     }
 
-    pub fn upsert(&self, table: String, key: u128, value: Vec<u8>) -> Result<bool, StorageError> {
+    pub fn upsert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<bool, StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
@@ -111,7 +111,7 @@ impl StorageBackend {
         Ok(true)
     }
 
-    pub fn exists(&self, table: String, key: u128) -> Result<bool, StorageError> {
+    pub fn exists(&self, table: &str, key: u128) -> Result<bool, StorageError> {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
@@ -120,7 +120,7 @@ impl StorageBackend {
         Ok(db.get(&ro_txn, &key)?.is_some())
     }
 
-    pub fn table_exists(&self, table: String) -> Result<bool, StorageError> {
+    pub fn table_exists(&self, table: &str) -> Result<bool, StorageError> {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
         let db = env.open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(&table))?;
@@ -138,7 +138,7 @@ impl StorageBackend {
         Ok(())
     }
 
-    pub fn create_table(&self, table: String) -> Result<(), StorageError> {
+    pub fn create_table(&self, table: &str) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         env.create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(&table))?;
@@ -176,13 +176,11 @@ mod tests {
         {
             let backend =
                 StorageBackend::initialize(Some(path.clone()), 10 * 1024 * 1024 * 1024).unwrap();
-            backend.create_table("test_table".to_string()).unwrap();
+            backend.create_table("test_table").unwrap();
             let key = 12345678901234567890u128;
             let value = vec![1, 2, 3, 4, 5];
-            backend
-                .insert("test_table".to_string(), key, value.clone())
-                .unwrap();
-            let retrieved_value = backend.get("test_table".to_string(), key).unwrap();
+            backend.insert("test_table", key, value.clone()).unwrap();
+            let retrieved_value = backend.get("test_table", key).unwrap();
             assert_eq!(retrieved_value, Some(value));
         }
         remove_dir_all(path).unwrap();
@@ -194,7 +192,7 @@ mod tests {
         {
             let backend =
                 StorageBackend::initialize(Some(path.clone()), 10 * 1024 * 1024 * 1024).unwrap();
-            backend.create_table("test_table".to_string()).unwrap();
+            backend.create_table("test_table").unwrap();
             let mut threads = vec![];
             for thread_iter in 0..10 {
                 let handle = std::thread::spawn({
@@ -203,9 +201,7 @@ mod tests {
                         for iter in 0..100 {
                             let key = hash_2_to_u128(iter, thread_iter);
                             let value = vec![rand::random::<u8>(); 10];
-                            backend
-                                .insert("test_table".to_string(), key, value)
-                                .unwrap();
+                            backend.insert("test_table", key, value).unwrap();
                         }
                     }
                 });
@@ -224,14 +220,12 @@ mod tests {
         {
             let backend =
                 StorageBackend::initialize(Some(path.clone()), 10 * 1024 * 1024 * 1024).unwrap();
-            backend.create_table("test_table".to_string()).unwrap();
+            backend.create_table("test_table").unwrap();
             for thread_iter in 0..10 {
                 for iter in 0..100 {
                     let value = vec![rand::random::<u8>(); 10];
                     let key = hash_2_to_u128(iter, thread_iter);
-                    backend
-                        .insert("test_table".to_string(), key, value)
-                        .unwrap();
+                    backend.insert("test_table", key, value).unwrap();
                 }
             }
             let mut threads = vec![];
@@ -241,7 +235,7 @@ mod tests {
                     move || {
                         for iter in 0..100 {
                             let key = hash_2_to_u128(iter, thread_iter);
-                            let _ = backend.get("test_table".to_string(), key).unwrap();
+                            let _ = backend.get("test_table", key).unwrap();
                         }
                     }
                 });

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -55,8 +55,7 @@ impl StorageBackend {
     pub fn insert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> =
-            env.create_database(&mut rw_txn, Some(&table))?;
+        let db: Database<U128<BigEndian>, Bytes> = env.create_database(&mut rw_txn, Some(table))?;
         if db.get_or_put(&mut rw_txn, &key, &value)?.is_some() {
             return Err(StorageError::KeyExists(key as u64));
         }
@@ -68,7 +67,7 @@ impl StorageBackend {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
-            .open_database(&ro_txn, Some(&table))?
+            .open_database(&ro_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         Ok(db.get(&ro_txn, &key)?.map(|v| v.to_vec()))
     }
@@ -77,7 +76,7 @@ impl StorageBackend {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
-            .open_database(&rw_txn, Some(&table))?
+            .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         if !db.delete(&mut rw_txn, &key)? {
             return Err(StorageError::KeyNotFound(key as u64));
@@ -90,7 +89,7 @@ impl StorageBackend {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
-            .open_database(&rw_txn, Some(&table))?
+            .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         if db.get(&rw_txn, &key)?.is_none() {
             return Err(StorageError::KeyNotFound(key as u64));
@@ -104,7 +103,7 @@ impl StorageBackend {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
-            .open_database(&rw_txn, Some(&table))?
+            .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         db.put(&mut rw_txn, &key, &value)?;
         rw_txn.commit()?;
@@ -115,7 +114,7 @@ impl StorageBackend {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
         let db: Database<U128<BigEndian>, Bytes> = env
-            .open_database(&ro_txn, Some(&table))?
+            .open_database(&ro_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         Ok(db.get(&ro_txn, &key)?.is_some())
     }
@@ -123,7 +122,7 @@ impl StorageBackend {
     pub fn table_exists(&self, table: &str) -> Result<bool, StorageError> {
         let env = self.env.lock();
         let ro_txn = env.read_txn()?;
-        let db = env.open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(&table))?;
+        let db = env.open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?;
         Ok(db.is_some())
     }
 
@@ -141,7 +140,7 @@ impl StorageBackend {
     pub fn create_table(&self, table: &str) -> Result<(), StorageError> {
         let env = self.env.lock();
         let mut rw_txn = env.write_txn()?;
-        env.create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(&table))?;
+        env.create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(table))?;
         rw_txn.commit()?;
         Ok(())
     }

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -3,13 +3,12 @@ use heed;
 use heed::byteorder::BigEndian;
 use heed::types::{Bytes, U128};
 use heed::{Database, Env, EnvOpenOptions, WithoutTls};
-use parking_lot::Mutex;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct StorageBackend {
-    pub env: Arc<Mutex<Env<WithoutTls>>>,
+    pub env: Arc<Env<WithoutTls>>,
 }
 
 impl From<heed::Error> for StorageError {
@@ -38,7 +37,7 @@ impl StorageBackend {
             * page_size::get() as f64) as usize;
         unsafe {
             let backend = StorageBackend {
-                env: Arc::new(Mutex::new(
+                env: Arc::new(
                     EnvOpenOptions::new()
                         .read_txn_without_tls()
                         // Change this as more tables are needed.
@@ -46,16 +45,16 @@ impl StorageBackend {
                         .map_size(rounded_map_size)
                         .open(checked_path)
                         .map_err(|e| StorageError::DatabaseInitError(e.to_string()))?,
-                )),
+                ),
             };
             Ok(backend)
         }
     }
 
     pub fn insert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
-        let env = self.env.lock();
-        let mut rw_txn = env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env.create_database(&mut rw_txn, Some(table))?;
+        let mut rw_txn = self.env.write_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> =
+            self.env.create_database(&mut rw_txn, Some(table))?;
         if db.get_or_put(&mut rw_txn, &key, &value)?.is_some() {
             return Err(StorageError::KeyExists(key as u64));
         }
@@ -64,18 +63,18 @@ impl StorageBackend {
     }
 
     pub fn get(&self, table: &str, key: u128) -> Result<Option<Vec<u8>>, StorageError> {
-        let env = self.env.lock();
-        let ro_txn = env.read_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env
+        let ro_txn = self.env.read_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> = self
+            .env
             .open_database(&ro_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         Ok(db.get(&ro_txn, &key)?.map(|v| v.to_vec()))
     }
 
     pub fn delete(&self, table: &str, key: u128) -> Result<(), StorageError> {
-        let env = self.env.lock();
-        let mut rw_txn = env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env
+        let mut rw_txn = self.env.write_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> = self
+            .env
             .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         if !db.delete(&mut rw_txn, &key)? {
@@ -86,9 +85,9 @@ impl StorageBackend {
     }
 
     pub fn update(&self, table: &str, key: u128, value: Vec<u8>) -> Result<(), StorageError> {
-        let env = self.env.lock();
-        let mut rw_txn = env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env
+        let mut rw_txn = self.env.write_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> = self
+            .env
             .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         if db.get(&rw_txn, &key)?.is_none() {
@@ -100,9 +99,9 @@ impl StorageBackend {
     }
 
     pub fn upsert(&self, table: &str, key: u128, value: Vec<u8>) -> Result<bool, StorageError> {
-        let env = self.env.lock();
-        let mut rw_txn = env.write_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env
+        let mut rw_txn = self.env.write_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> = self
+            .env
             .open_database(&rw_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         db.put(&mut rw_txn, &key, &value)?;
@@ -111,36 +110,36 @@ impl StorageBackend {
     }
 
     pub fn exists(&self, table: &str, key: u128) -> Result<bool, StorageError> {
-        let env = self.env.lock();
-        let ro_txn = env.read_txn()?;
-        let db: Database<U128<BigEndian>, Bytes> = env
+        let ro_txn = self.env.read_txn()?;
+        let db: Database<U128<BigEndian>, Bytes> = self
+            .env
             .open_database(&ro_txn, Some(table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
         Ok(db.get(&ro_txn, &key)?.is_some())
     }
 
     pub fn table_exists(&self, table: &str) -> Result<bool, StorageError> {
-        let env = self.env.lock();
-        let ro_txn = env.read_txn()?;
-        let db = env.open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?;
+        let ro_txn = self.env.read_txn()?;
+        let db = self
+            .env
+            .open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?;
         Ok(db.is_some())
     }
 
     pub fn details(&self) -> String {
-        format!("LMDB (heed 0.20.5): {:?}", self.env.lock().info())
+        format!("LMDB (heed 0.20.5): {:?}", self.env.info())
     }
 
     pub fn flush(&self) -> Result<(), StorageError> {
-        let env = self.env.lock();
-        env.clear_stale_readers()?;
-        env.force_sync()?;
+        self.env.clear_stale_readers()?;
+        self.env.force_sync()?;
         Ok(())
     }
 
     pub fn create_table(&self, table: &str) -> Result<(), StorageError> {
-        let env = self.env.lock();
-        let mut rw_txn = env.write_txn()?;
-        env.create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(table))?;
+        let mut rw_txn = self.env.write_txn()?;
+        self.env
+            .create_database::<U128<BigEndian>, Bytes>(&mut rw_txn, Some(table))?;
         rw_txn.commit()?;
         Ok(())
     }
@@ -150,7 +149,7 @@ impl StorageBackend {
         Ok(())
     }
 
-    pub fn get_env(&self) -> Arc<Mutex<Env<WithoutTls>>> {
+    pub fn get_env(&self) -> Arc<Env<WithoutTls>> {
         self.env.clone()
     }
 }

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 pub struct StorageBackend {
     pub env: Arc<Env<WithoutTls>>,
     dbs: Arc<DashMap<String, Database<U128<BigEndian>, Bytes>>>,
-    dbi_open_lock: Arc<parking_lot::Mutex<()>>,
+    dbi_open_lock: Arc<Mutex<()>>,
 }
 
 impl From<heed::Error> for StorageError {
@@ -51,7 +51,7 @@ impl StorageBackend {
                         .map_err(|e| StorageError::DatabaseInitError(e.to_string()))?,
                 ),
                 dbs: Arc::new(DashMap::new()),
-                dbi_open_lock: Arc::new(parking_lot::Mutex::new(())),
+                dbi_open_lock: Arc::new(Mutex::new(())),
             };
             Ok(backend)
         }
@@ -109,7 +109,25 @@ impl StorageBackend {
     }
 
     pub fn table_exists(&self, table: &str) -> Result<bool, StorageError> {
-        Ok(self.dbs.contains_key(table))
+        if self.dbs.contains_key(table) {
+            return Ok(true);
+        }
+        let _lock = self.dbi_open_lock.lock();
+        if self.dbs.contains_key(table) {
+            return Ok(true);
+        }
+        let rw_txn = self.env.write_txn()?;
+        match self
+            .env
+            .open_database::<U128<BigEndian>, Bytes>(&rw_txn, Some(table))?
+        {
+            Some(db) => {
+                rw_txn.commit()?;
+                self.dbs.insert(table.to_string(), db);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     pub fn details(&self) -> String {
@@ -152,11 +170,12 @@ impl StorageBackend {
         if let Some(db) = self.dbs.get(table) {
             return Ok(*db);
         }
-        let ro_txn = self.env.read_txn()?;
+        let rw_txn = self.env.write_txn()?;
         let db = self
             .env
-            .open_database::<U128<BigEndian>, Bytes>(&ro_txn, Some(table))?
+            .open_database::<U128<BigEndian>, Bytes>(&rw_txn, Some(table))?
             .ok_or_else(|| StorageError::TableError("Table not found".to_string()))?;
+        rw_txn.commit()?;
         self.dbs.insert(table.to_string(), db);
         Ok(db)
     }

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -57,10 +57,9 @@ impl StorageBackend {
         let mut rw_txn = env.write_txn()?;
         let db: Database<U128<BigEndian>, Bytes> =
             env.create_database(&mut rw_txn, Some(&table))?;
-        if db.get(&rw_txn, &key)?.is_some() {
+        if db.get_or_put(&mut rw_txn, &key, &value)?.is_some() {
             return Err(StorageError::KeyExists(key as u64));
         }
-        db.put(&mut rw_txn, &key, &value)?;
         rw_txn.commit()?;
         Ok(())
     }
@@ -71,12 +70,7 @@ impl StorageBackend {
         let db: Database<U128<BigEndian>, Bytes> = env
             .open_database(&ro_txn, Some(&table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
-        let value = db.get(&ro_txn, &key)?;
-        if let Some(v) = value {
-            Ok(Some(v.to_vec()))
-        } else {
-            Ok(None)
-        }
+        Ok(db.get(&ro_txn, &key)?.map(|v| v.to_vec()))
     }
 
     pub fn delete(&self, table: String, key: u128) -> Result<(), StorageError> {
@@ -85,10 +79,9 @@ impl StorageBackend {
         let db: Database<U128<BigEndian>, Bytes> = env
             .open_database(&rw_txn, Some(&table))?
             .ok_or(StorageError::TableError("Table not found".to_string()))?;
-        if db.get(&rw_txn, &key)?.is_none() {
+        if !db.delete(&mut rw_txn, &key)? {
             return Err(StorageError::KeyNotFound(key as u64));
         }
-        db.delete(&mut rw_txn, &key)?;
         rw_txn.commit()?;
         Ok(())
     }

--- a/src/storage/src/lmdb.rs
+++ b/src/storage/src/lmdb.rs
@@ -131,7 +131,7 @@ impl StorageBackend {
     }
 
     pub fn details(&self) -> String {
-        format!("LMDB (heed 0.20.5): {:?}", self.env.info())
+        format!("LMDB (heed 0.22.1): {:?}", self.env.info())
     }
 
     pub fn flush(&self) -> Result<(), StorageError> {

--- a/src/world/db/src/chunks.rs
+++ b/src/world/db/src/chunks.rs
@@ -14,8 +14,8 @@ pub fn save_chunk_internal(
     dimension: Dimension,
     chunk: &Chunk,
 ) -> Result<(), WorldError> {
-    if !storage.table_exists("chunks".to_string())? {
-        storage.create_table("chunks".to_string())?;
+    if !storage.table_exists("chunks")? {
+        storage.create_table("chunks")?;
     }
     let as_bytes = yazi::compress(
         &bitcode::serialize(chunk).expect("Unable to serialize chunk"),
@@ -23,7 +23,7 @@ pub fn save_chunk_internal(
         CompressionLevel::BestSpeed,
     )?;
     let digest = create_key(dimension, pos);
-    storage.upsert("chunks".to_string(), digest, as_bytes)?;
+    storage.upsert("chunks", digest, as_bytes)?;
     Ok(())
 }
 
@@ -34,7 +34,7 @@ pub fn load_chunk_internal(
     verify: bool,
 ) -> Result<Chunk, WorldError> {
     let digest = create_key(dimension, pos);
-    match storage.get("chunks".to_string(), digest)? {
+    match storage.get("chunks", digest)? {
         Some(compressed) => {
             let (data, checksum) = yazi::decompress(compressed.as_slice(), yazi::Format::Zlib)?;
             if verify {
@@ -60,11 +60,11 @@ pub fn chunk_exists_internal(
     pos: ChunkPos,
     dimension: Dimension,
 ) -> Result<bool, WorldError> {
-    if !storage.table_exists("chunks".to_string())? {
+    if !storage.table_exists("chunks")? {
         return Ok(false);
     }
     let digest = create_key(dimension, pos);
-    Ok(storage.exists("chunks".to_string(), digest)?)
+    Ok(storage.exists("chunks", digest)?)
 }
 
 pub fn delete_chunk_internal(
@@ -73,7 +73,7 @@ pub fn delete_chunk_internal(
     dimension: Dimension,
 ) -> Result<(), WorldError> {
     let digest = create_key(dimension, pos);
-    storage.delete("chunks".to_string(), digest)?;
+    storage.delete("chunks", digest)?;
     Ok(())
 }
 

--- a/src/world/src/importing.rs
+++ b/src/world/src/importing.rs
@@ -54,7 +54,7 @@ impl World {
 
         progress.set_message("Setting up database and preparing import...");
 
-        self.storage_backend.create_table("chunks".to_string())?;
+        self.storage_backend.create_table("chunks")?;
 
         let start = std::time::Instant::now();
 

--- a/src/world/src/player.rs
+++ b/src/world/src/player.rs
@@ -22,10 +22,7 @@ impl World {
         &self,
         uuid: uuid::Uuid,
     ) -> Result<Option<T>, WorldError> {
-        if !self
-            .storage_backend
-            .table_exists("player_data".to_string())?
-        {
+        if !self.storage_backend.table_exists("player_data")? {
             trace!(
                 "Player data table does not exist. Returning None for player {}",
                 uuid
@@ -34,7 +31,7 @@ impl World {
         }
         let data = self
             .storage_backend
-            .get("player_data".to_string(), uuid.as_u128())
+            .get("player_data", uuid.as_u128())
             .map_err(WorldError::DatabaseError);
         data.map(|opt_bytes| opt_bytes.and_then(|bytes| bitcode::decode(&bytes).ok()))
     }
@@ -60,20 +57,13 @@ impl World {
         uuid: uuid::Uuid,
         data: &T,
     ) -> Result<bool, WorldError> {
-        if !self
-            .storage_backend
-            .table_exists("player_data".to_string())?
-        {
+        if !self.storage_backend.table_exists("player_data")? {
             self.storage_backend
-                .create_table("player_data".to_string())
+                .create_table("player_data")
                 .map_err(WorldError::DatabaseError)?;
         }
         self.storage_backend
-            .upsert(
-                "player_data".to_string(),
-                uuid.as_u128(),
-                bitcode::encode(data),
-            )
+            .upsert("player_data", uuid.as_u128(), bitcode::encode(data))
             .map_err(WorldError::DatabaseError)
     }
 }


### PR DESCRIPTION
So this PR fixes :

1. Deletion of the global Mutex

- Before we have `Arc<Mutex<Env<WithoutTls>>>` all operation are serialized over only one lock
- Now we have `Arc<Env<WithoutTls>>` all read operation are concurrent, let LMDB handle his own sync

2. Insert : 2 I/O -> 1 I/O

- Before: get() + put() to write
- Now : get_or_put()

3. Delete : 2 I/O -> 1 I/O

- More or less same as 2. (see delete func)

4. Caching handles (DBI)

- Before: open_database() (mdb_dbi_open called for every operations)
- Now : DashMap to cache handle after the first time
> (btw that fix heap crash append cause mdb_dbi_open isnt thread-safe in concurrent)

5. use &str instead of String for table name

- Just because it need to be **BlAzInGly fAsT**