### PR TITLE
[feat] Simple friction physics

### DIFF
--- a/src/default_commands/src/lib.rs
+++ b/src/default_commands/src/lib.rs
@@ -3,6 +3,7 @@ mod credits;
 pub mod echo;
 pub mod gamemode;
 mod kill;
+mod motion;
 pub mod op;
 mod stop;
 mod summon;

--- a/src/default_commands/src/motion.rs
+++ b/src/default_commands/src/motion.rs
@@ -1,0 +1,55 @@
+use bevy_ecs::prelude::{Entity, Query};
+use bevy_ecs::query::Without;
+use temper_command_infra::args::{EntitiesArg, PositionArg};
+use temper_command_infra::{CommandHandler, CommandResult, CommandSource};
+use temper_components::entity_identity::Identity;
+use temper_components::player::player_marker::PlayerMarker;
+use temper_components::player::position::Position;
+use temper_components::player::velocity::Velocity;
+use temper_macros::Command;
+use temper_permissions::Permissions;
+
+#[derive(Debug, Command)]
+#[command(name = "motion", permission = Permissions::Op)]
+struct MotionCommand {
+    target: EntitiesArg,
+    offset: PositionArg,
+}
+
+impl CommandHandler for MotionCommand {
+    type SystemParam<'w, 's> = (
+        Query<'w, 's, (Entity, &'static Identity, Option<&'static PlayerMarker>)>,
+        Query<'w, 's, (&'static Identity, &'static mut Velocity), Without<PlayerMarker>>,
+    );
+
+    fn handle(
+        self,
+        source: CommandSource,
+        params: &mut Self::SystemParam<'_, '_>,
+    ) -> CommandResult {
+        let (entity_query, motion_targets) = params;
+
+        let entities = self.target.resolve(entity_query.iter());
+
+        let offset = self.offset.resolve(&Position::new(0f64, 0f64, 0f64));
+
+        for entity in &entities {
+            if let Ok((_, mut velocity)) = motion_targets.get_mut(*entity) {
+                velocity.vec += offset.as_vec3a();
+            }
+        }
+
+        source.send_message(
+            format!(
+                "Added velocity of ~{} ~{} ~{} for {} entitie(s)",
+                offset.x,
+                offset.y,
+                offset.z,
+                entities.len()
+            )
+            .into(),
+        );
+
+        Ok(())
+    }
+}

--- a/src/game_systems/src/lib.rs
+++ b/src/game_systems/src/lib.rs
@@ -127,6 +127,7 @@ fn register_tick_systems(schedule: &mut Schedule) {
             physics::unground::handle,
             physics::gravity::handle,
             physics::drag::handle,
+            physics::friction::handle,
             physics::velocity::handle,
             physics::collisions::handle,
             physics::chunk_boundary::handle,

--- a/src/game_systems/src/physics/src/friction.rs
+++ b/src/game_systems/src/physics/src/friction.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::system::Query;
+use bevy_math::Vec3A;
+use temper_components::player::velocity::Velocity;
+
+pub fn handle(mut query: Query<&mut Velocity>) {
+    for mut vel in query.iter_mut() {
+        //TODO: proper dampen
+        if vel.length() <= 0.001 {
+            **vel = Vec3A::ZERO;
+        }
+        const DAMPEN_AMOUNT: Vec3A = Vec3A::new(0.9, 0.99, 0.9);
+        **vel *= DAMPEN_AMOUNT;
+    }
+}

--- a/src/game_systems/src/physics/src/lib.rs
+++ b/src/game_systems/src/physics/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod chunk_boundary;
 pub mod collisions;
 pub mod drag;
+pub mod friction;
 pub mod gravity;
 pub mod unground;
 pub mod velocity;


### PR DESCRIPTION
Currently mobs when they have velocity it never goes back to zero because there is no friction this adds a quick simple system to reduce the velocity every tick a more complicated/accurate friction to Minecraft can come later.