### PR TITLE
Use correct syntax for cargo:error in temper-assets build script

### DIFF
--- a/src/assets/build/downloading.rs
+++ b/src/assets/build/downloading.rs
@@ -77,7 +77,7 @@ pub fn generate() {
         write_if_changed(assets_dir.join("version"), crate::SERVER_VERSION)
             .expect("Could not write version file");
     } else {
-        println!("cargo:error=Setup failed");
+        println!("cargo::error=Setup failed");
     }
 }
 
@@ -133,7 +133,7 @@ fn setup() -> Result<PathBuf, ()> {
                 .expect("Failed to create generated assets directory");
         } else {
             println!(
-                "cargo:error=Parent directory of generated assets does not exist, is {:?} the right directory for the project?",
+                "cargo::error=Parent directory of generated assets does not exist, is {:?} the right directory for the project?",
                 root
             );
             return Err(());

--- a/src/assets/build/main.rs
+++ b/src/assets/build/main.rs
@@ -33,7 +33,7 @@ fn main() {
     );
     let java_path = match which::which("java") {
         Err(_) => {
-            println!("cargo:error={}", NO_JAVA_MESSAGE);
+            println!("cargo::error={}", NO_JAVA_MESSAGE);
             return;
         }
         Ok(path) => path,
@@ -42,7 +42,7 @@ fn main() {
     if let Some(is_higher) = check_version(java_path) {
         if !is_higher {
             println!(
-                "cargo:error=Java version is lower than the minimum required version of {}. Please update your Java installation.",
+                "cargo::error=Java version is lower than the minimum required version of {}. Please update your Java installation.",
                 MIN_JAVA_VERSION
             );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the `temper-assets` build script to use the correct syntax for printing errors through cargo.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
My builds would repeatedly fail because I didn't have Java installed. However, I didn't figure this out for a while because no error messages were being printed and the build script would exit as if it successfully completed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I reran `cargo b` before installing java and saw the error message telling me to install it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructuring code, without changing its behavior)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Clippy passes with no warnings.