### PR TITLE
Fix network serialization for DirectSection

### DIFF
--- a/src/world/format/src/section/network.rs
+++ b/src/world/format/src/section/network.rs
@@ -89,11 +89,11 @@ impl<'section> From<&'section PalettedSection> for PalettedContainer<'section> {
 }
 
 impl<'section> From<&'section DirectSection> for PalettedContainer<'section> {
-    fn from(_section: &'section DirectSection) -> Self {
+    fn from(section: &'section DirectSection) -> Self {
         PalettedContainer {
             bits_per_entry: 16,
             palette: NetworkPalette::Direct {},
-            data_array: NetworkArray::new_owned(vec![]), // TODO: fix this to use the data from the section; bytemuck::cast_slice(&section.0)
+            data_array: NetworkArray::new_borrowed(bytemuck::cast_slice(&section.0)),
         }
     }
 }


### PR DESCRIPTION
Fixes #36, as described there and in line 96. `data_array` is now set to the block state data from the section, rather than just `vec![]`.