### PR TITLE
Post CI results as a comment

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,6 +98,7 @@ jobs:
     name: Run Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-14
@@ -131,4 +132,22 @@ jobs:
           tool: cargo-nextest
 
       - name: Run Tests
-        run: cargo nextest run --target ${{ matrix.target }} --all-targets --all-features -E "not kind(bench)"
+        run: cargo nextest run --profile ci --target ${{ matrix.target }} --all-targets --all-features -E "not kind(bench)"
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.target }}
+          path: target/nextest/ci/junit.xml
+
+  event_file:
+    name: Event File
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload event file
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,48 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: [ "Rust CI" ]
+    types: [ completed ]
+
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    if: ${{ github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: test-results-*
+          path: artifacts/test-results
+
+      - name: Download event file
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: event-file
+          path: artifacts/event-file
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: artifacts/test-results/**/*.xml
+          check_run: false
+          job_summary: false


### PR DESCRIPTION
Uses nextest's junit output and another workflow to post the output of the tests to a comment. Should be kinda cool I hope.