### PR TITLE
Fix/chunk gen stalls

### DIFF
--- a/src/app/runtime/src/lib.rs
+++ b/src/app/runtime/src/lib.rs
@@ -58,4 +58,9 @@ pub fn shutdown_handler(state: GlobalState) {
     state
         .shut_down
         .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    state
+        .world
+        .sync()
+        .expect("Failed to sync world before shutdown")
 }

--- a/src/components/Cargo.toml
+++ b/src/components/Cargo.toml
@@ -19,6 +19,7 @@ uuid = { workspace = true }
 type_hash = { workspace = true }
 serde = { workspace = true }
 crossbeam-queue = { workspace = true }
+crossbeam-channel = { workspace = true }
 temper-permissions = { workspace = true }
 rand = { workspace = true }
 

--- a/src/components/src/player/chunk_receiver.rs
+++ b/src/components/src/player/chunk_receiver.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::Component;
 use crossbeam_channel::{unbounded, Receiver, Sender};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use temper_core::pos::ChunkPos;
 use uuid::Uuid;
 
@@ -35,6 +35,7 @@ pub struct ChunkReceiver {
     pub chunks_per_tick: f32,
     pub ready_tx: Sender<PreparedChunk>,
     pub ready_rx: Receiver<PreparedChunk>,
+    pub retry_counts: HashMap<(i32, i32), u8>,
 }
 
 impl ChunkReceiver {
@@ -49,6 +50,7 @@ impl ChunkReceiver {
             chunks_per_tick: 32.5,
             ready_tx,
             ready_rx,
+            retry_counts: HashMap::new(),
         }
     }
 }

--- a/src/components/src/player/chunk_receiver.rs
+++ b/src/components/src/player/chunk_receiver.rs
@@ -4,11 +4,25 @@ use std::collections::{HashSet, VecDeque};
 use temper_core::pos::ChunkPos;
 use uuid::Uuid;
 
-pub struct PreparedChunk {
-    pub pos: ChunkPos,
-    pub packet_data: Vec<u8>,
-    pub entities: Vec<(Uuid, u16)>,
-    pub is_new_load: bool,
+pub enum PreparedChunk {
+    Ready {
+        pos: ChunkPos,
+        packet_data: Vec<u8>,
+        entities: Vec<(Uuid, u16)>,
+        is_new_load: bool,
+    },
+    Failed {
+        pos: ChunkPos,
+    },
+}
+
+impl PreparedChunk {
+    /// The chunk this message is about, whether it succeeded or not.
+    pub fn pos(&self) -> ChunkPos {
+        match self {
+            Self::Ready { pos, .. } | Self::Failed { pos } => *pos,
+        }
+    }
 }
 
 #[derive(Component)]

--- a/src/components/src/player/chunk_receiver.rs
+++ b/src/components/src/player/chunk_receiver.rs
@@ -1,29 +1,46 @@
 use bevy_ecs::prelude::Component;
+use crossbeam_channel::{unbounded, Receiver, Sender};
 use std::collections::{HashSet, VecDeque};
+use temper_core::pos::ChunkPos;
+use uuid::Uuid;
+
+pub struct PreparedChunk {
+    pub pos: ChunkPos,
+    pub packet_data: Vec<u8>,
+    pub entities: Vec<(Uuid, u16)>,
+    pub is_new_load: bool,
+}
+
 #[derive(Component)]
 pub struct ChunkReceiver {
     pub loading: VecDeque<(i32, i32)>,
     pub dirty: VecDeque<(i32, i32)>,
     pub loaded: HashSet<(i32, i32)>,
+    pub in_flight: HashSet<(i32, i32)>, // dispatched, not yet harvested
     pub unloading: VecDeque<(i32, i32)>,
     pub chunks_per_tick: f32,
+    pub ready_tx: Sender<PreparedChunk>,
+    pub ready_rx: Receiver<PreparedChunk>,
+}
+
+impl ChunkReceiver {
+    pub fn new() -> Self {
+        let (ready_tx, ready_rx) = unbounded();
+        Self {
+            loading: VecDeque::new(),
+            loaded: HashSet::new(),
+            in_flight: HashSet::new(),
+            unloading: VecDeque::new(),
+            dirty: VecDeque::new(),
+            chunks_per_tick: 32.5,
+            ready_tx,
+            ready_rx,
+        }
+    }
 }
 
 impl Default for ChunkReceiver {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl ChunkReceiver {
-    pub fn new() -> Self {
-        Self {
-            loading: VecDeque::new(),
-            loaded: HashSet::new(),
-            unloading: VecDeque::new(),
-            dirty: VecDeque::new(),
-            // 32.5 chunks per tick is enough to send 650 chunks per second (20 ticks per second)
-            chunks_per_tick: 32.5,
-        }
     }
 }

--- a/src/default_commands/src/stop.rs
+++ b/src/default_commands/src/stop.rs
@@ -21,6 +21,11 @@ impl CommandHandler for StopCommand {
 
         info!("Shutting down server...");
         state.0.shut_down.store(true, Relaxed);
+        state
+            .0
+            .world
+            .sync()
+            .map_err(|error| format!("Failed to sync world before shutdown: {error}"))?;
 
         Ok(())
     }

--- a/src/game_systems/Cargo.toml
+++ b/src/game_systems/Cargo.toml
@@ -29,6 +29,7 @@ temper-macros = { workspace = true }
 temper-messages = { workspace = true }
 temper-resources = { workspace = true }
 temper-state = { workspace = true }
+temper-world = {workspace = true}
 
 [lints]
 workspace = true

--- a/src/game_systems/src/background/src/chunk_sending.rs
+++ b/src/game_systems/src/background/src/chunk_sending.rs
@@ -19,6 +19,9 @@ use temper_protocol::outgoing::set_center_chunk::SetCenterChunk;
 use temper_state::GlobalStateResource;
 use tracing::error;
 
+/// How many times a chunk may fail to prepare before we stop retrying it.
+const MAX_CHUNK_RETRIES: u8 = 3;
+
 pub fn handle(
     mut query: Query<(
         Entity,
@@ -58,10 +61,27 @@ pub fn handle(
         let mut ready_to_send = Vec::new();
         for prepared in harvested {
             match prepared {
-                PreparedChunk::Ready { .. } => ready_to_send.push(prepared),
+                PreparedChunk::Ready { pos, .. } => {
+                    // Success wipes the failure history for this chunk, so a
+                    // chunk that fails twice then succeeds starts clean.
+                    chunk_receiver.retry_counts.remove(&(pos.x(), pos.z()));
+                    ready_to_send.push(prepared);
+                }
                 PreparedChunk::Failed { pos } => {
-                    // Put it back in the queue for another attempt next tick.
-                    chunk_receiver.loading.push_back((pos.x(), pos.z()));
+                    let key = (pos.x(), pos.z());
+                    let attempts = chunk_receiver.retry_counts.entry(key).or_insert(0);
+                    *attempts += 1;
+
+                    if *attempts >= MAX_CHUNK_RETRIES {
+                        error!(
+                            "Chunk {:?} failed to prepare {} times; giving up for this session",
+                            pos, attempts
+                        );
+                        chunk_receiver.retry_counts.remove(&key);
+                    } else {
+                        // Put it back in the queue for another attempt next tick.
+                        chunk_receiver.loading.push_back(key);
+                    }
                 }
             }
         }
@@ -87,7 +107,7 @@ pub fn handle(
                     is_new_load,
                 } = chunk
                 else {
-                    continue; // filtered above; can't happen
+                    unreachable!();
                 };
 
                 chunk_receiver.loaded.insert((chunk_pos.x(), chunk_pos.z()));

--- a/src/game_systems/src/background/src/chunk_sending.rs
+++ b/src/game_systems/src/background/src/chunk_sending.rs
@@ -1,12 +1,10 @@
 use bevy_ecs::prelude::{Entity, MessageWriter, Query, Res};
 use bevy_math::{IVec2, IVec3};
-use crossbeam_queue::SegQueue;
 use std::cmp::max;
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use temper_codec::encode::NetEncodeOpts;
-use temper_components::player::chunk_receiver::ChunkReceiver;
+use temper_components::player::chunk_receiver::{ChunkReceiver, PreparedChunk};
 use temper_components::player::client_information::ClientInformationComponent;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::position::Position;
@@ -21,8 +19,6 @@ use temper_protocol::outgoing::set_center_chunk::SetCenterChunk;
 use temper_state::GlobalStateResource;
 use tracing::error;
 
-// Just take the needed chunks from the ChunkReceiver and send them
-// calculating which chunks are required is figured out elsewhere
 pub fn handle(
     mut query: Query<(
         Entity,
@@ -37,9 +33,76 @@ pub fn handle(
 ) {
     for (eid, conn, mut chunk_receiver, pos, client_info, entity_tracker) in query.iter_mut() {
         if !state.0.players.is_connected(eid) {
-            continue; // Skip if the player is not connected
+            continue;
         }
 
+        let chunk_receiver = &mut *chunk_receiver;
+
+        // ==========================================
+        // PHASE 1: HARVEST & SEND COMPLETED CHUNKS
+        // ==========================================
+        let mut ready_to_send = Vec::new();
+
+        // Pull everything that has finished generating in the background
+        while let Ok(prepared) = chunk_receiver.ready_rx.try_recv() {
+            ready_to_send.push(prepared);
+        }
+
+        if !ready_to_send.is_empty() {
+            conn.send_packet(ChunkBatchStart {})
+                .expect("Failed to send ChunkBatchStart");
+
+            let center_chunk: IVec3 = pos.coords.floor().as_ivec3() >> 4;
+            conn.send_packet(SetCenterChunk {
+                x: center_chunk.x.into(),
+                z: center_chunk.z.into(),
+            })
+            .expect("Failed to send SetCenterChunk");
+
+            let packets_len = ready_to_send.len();
+
+            for chunk in ready_to_send {
+                chunk_receiver
+                    .in_flight
+                    .remove(&(chunk.pos.x(), chunk.pos.z())); // Mark this chunk as no longer in-flight since it has been sent
+                chunk_receiver.loaded.insert((chunk.pos.x(), chunk.pos.z()));
+
+                if chunk.is_new_load {
+                    mob_load_writer.write(temper_messages::load_chunk_entities::LoadChunkEntities(
+                        chunk.pos,
+                    ));
+                }
+
+                if let Err(err) = conn.send_raw_packet(chunk.packet_data) {
+                    error!("Failed to send chunk packet: {:?}", err);
+                }
+
+                for entity_tuple in chunk.entities {
+                    entity_tracker.to_track.push(entity_tuple);
+                }
+            }
+
+            if let Err(err) = conn.send_packet(ChunkBatchFinish {
+                batch_size: packets_len.into(),
+            }) {
+                error!("Failed to send ChunkBatchFinish packet: {:?}", err);
+            }
+        }
+
+        // tell the client to unload chunks that are no longer needed
+        while let Some(coords) = chunk_receiver.unloading.pop_front() {
+            let packet = temper_protocol::outgoing::unload_chunk::UnloadChunk {
+                x: coords.0,
+                z: coords.1,
+            };
+            if let Err(err) = conn.send_packet(packet) {
+                error!("Failed to send UnloadChunk packet: {:?}", err);
+            }
+        }
+
+        // ==========================================
+        // PHASE 2: DISPATCH NEW CHUNKS (NON-BLOCKING)
+        // ==========================================
         let chunk_per_tick = match state.0.config.performance.chunks_per_tick {
             0 => max(
                 chunk_receiver.loading.len() / 3,
@@ -53,14 +116,11 @@ pub fn handle(
             continue;
         }
 
-        let chunk_receiver = &mut *chunk_receiver;
-
         let mut dirty_chunks = Vec::new();
         let mut sent_chunks = 0;
 
-        // First handle dirty chunks
-        while let Some(coords) = &chunk_receiver.dirty.pop_front() {
-            dirty_chunks.push(*coords);
+        while let Some(coords) = chunk_receiver.dirty.pop_front() {
+            dirty_chunks.push(coords);
             sent_chunks += 1;
             if sent_chunks >= chunk_per_tick {
                 break;
@@ -70,7 +130,6 @@ pub fn handle(
         let mut needed_chunks: Vec<(i32, i32)> = Vec::new();
 
         if sent_chunks < chunk_receiver.chunks_per_tick as usize {
-            // Then handle loading chunks
             while let Some(coords) = chunk_receiver.loading.pop_front() {
                 needed_chunks.push(coords);
                 sent_chunks += 1;
@@ -85,23 +144,9 @@ pub fn handle(
 
         if needed_chunks.is_empty() {
             continue;
-        };
+        }
 
-        let mut batch = state.0.thread_pool.batch();
-
-        conn.send_packet(ChunkBatchStart {})
-            .expect("Failed to send ChunkBatchStart");
-
-        let center_chunk: IVec3 = pos.coords.floor().as_ivec3() >> 4;
-
-        conn.send_packet(SetCenterChunk {
-            x: center_chunk.x.into(),
-            z: center_chunk.z.into(),
-        })
-        .expect("Failed to send SetCenterChunk");
-
-        let entity_queue = Arc::new(SegQueue::new());
-
+        // dispatch to the thread pool
         for coordinates in needed_chunks
             .into_iter()
             .filter(|coord| {
@@ -119,70 +164,50 @@ pub fn handle(
             })
             .map(|c| ChunkPos::new(c.0, c.1))
         {
-            chunk_receiver
-                .loaded
-                .insert((coordinates.x(), coordinates.z()));
-            let state = state.clone();
-            if loading_chunks.contains(&(coordinates.x(), coordinates.z())) {
-                mob_load_writer.write(temper_messages::load_chunk_entities::LoadChunkEntities(
-                    coordinates,
-                ));
-            }
+            let is_new_load = loading_chunks.contains(&(coordinates.x(), coordinates.z()));
             let is_compressed = conn.compress.load(Ordering::Relaxed);
-            batch.execute({
-                let entity_queue = entity_queue.clone();
-                move || {
-                    let chunk = state
+
+            let state_clone = state.clone();
+            let tx = chunk_receiver.ready_tx.clone();
+
+            chunk_receiver
+                .in_flight
+                .insert((coordinates.x(), coordinates.z())); // Mark this chunk as in-flight to prevent duplicate generation
+
+            state.0.thread_pool.oneshot(move || {
+                let chunk_data = {
+                    let chunk_ref = state_clone
                         .0
                         .world
                         .get_or_generate_chunk(coordinates, Dimension::Overworld)
                         .expect("Failed to load or generate chunk");
-                    for kv in chunk.entities.iter() {
-                        entity_queue.push((*kv.key(), kv.value().0.to_entity_type().id));
-                    }
-                    let chunk = (*chunk).clone();
 
-                    let packet = ChunkAndLightData::from_chunk(coordinates, &chunk)
-                        .expect("Failed to create ChunkAndLightData");
-                    compress_packet(
-                        &packet,
-                        is_compressed,
-                        &NetEncodeOpts::WithLength,
-                        state.0.config.network_compression_threshold as usize,
-                    )
-                    .expect("Failed to compress ChunkAndLightData packet")
+                    (*chunk_ref).clone_without_transient_noise()
+                };
+
+                let mut entities = Vec::new();
+                for kv in chunk_data.entities.iter() {
+                    entities.push((*kv.key(), kv.value().0.to_entity_type().id));
                 }
+
+                let packet = ChunkAndLightData::from_chunk(coordinates, &chunk_data)
+                    .expect("Failed to create ChunkAndLightData");
+
+                let packet_data = compress_packet(
+                    &packet,
+                    is_compressed,
+                    &NetEncodeOpts::WithLength,
+                    state_clone.0.config.network_compression_threshold as usize,
+                )
+                .expect("Failed to compress ChunkAndLightData packet");
+
+                let _ = tx.send(PreparedChunk {
+                    pos: coordinates,
+                    packet_data,
+                    entities,
+                    is_new_load,
+                });
             });
-        }
-        let packets = batch.wait();
-        let packets_len = packets.len();
-        for packet in packets {
-            if let Err(err) = conn.send_raw_packet(packet) {
-                error!("Failed to send chunk packet: {:?}", err);
-            }
-        }
-
-        if let Err(err) = conn.send_packet(ChunkBatchFinish {
-            batch_size: packets_len.into(),
-        }) {
-            error!("Failed to send ChunkBatchFinish packet: {:?}", err);
-        }
-
-        // Tell the client to unload chunks that are no longer needed
-
-        while let Some(coords) = &chunk_receiver.unloading.pop_front() {
-            let packet = temper_protocol::outgoing::unload_chunk::UnloadChunk {
-                x: coords.0,
-                z: coords.1,
-            };
-            if let Err(err) = conn.send_packet(packet) {
-                error!("Failed to send UnloadChunk packet: {:?}", err);
-            }
-        }
-
-        // God, I hope the compiler can optimize this shit out
-        while let Some(entity_id) = entity_queue.pop() {
-            entity_tracker.to_track.push(entity_id);
         }
     }
 }

--- a/src/game_systems/src/background/src/chunk_sending.rs
+++ b/src/game_systems/src/background/src/chunk_sending.rs
@@ -41,11 +41,29 @@ pub fn handle(
         // ==========================================
         // PHASE 1: HARVEST & SEND COMPLETED CHUNKS
         // ==========================================
-        let mut ready_to_send = Vec::new();
+        let mut harvested = Vec::new();
 
-        // Pull everything that has finished generating in the background
+        // Pull everything the pool has finished with — successes and failures
         while let Ok(prepared) = chunk_receiver.ready_rx.try_recv() {
-            ready_to_send.push(prepared);
+            harvested.push(prepared);
+        }
+
+        // Anything harvested is no longer in flight, whatever its outcome.
+        // This is what stops a failure from stranding the coordinate forever.
+        for prepared in &harvested {
+            let pos = prepared.pos();
+            chunk_receiver.in_flight.remove(&(pos.x(), pos.z()));
+        }
+
+        let mut ready_to_send = Vec::new();
+        for prepared in harvested {
+            match prepared {
+                PreparedChunk::Ready { .. } => ready_to_send.push(prepared),
+                PreparedChunk::Failed { pos } => {
+                    // Put it back in the queue for another attempt next tick.
+                    chunk_receiver.loading.push_back((pos.x(), pos.z()));
+                }
+            }
         }
 
         if !ready_to_send.is_empty() {
@@ -62,22 +80,29 @@ pub fn handle(
             let packets_len = ready_to_send.len();
 
             for chunk in ready_to_send {
-                chunk_receiver
-                    .in_flight
-                    .remove(&(chunk.pos.x(), chunk.pos.z())); // Mark this chunk as no longer in-flight since it has been sent
-                chunk_receiver.loaded.insert((chunk.pos.x(), chunk.pos.z()));
+                let PreparedChunk::Ready {
+                    pos: chunk_pos,
+                    packet_data,
+                    entities,
+                    is_new_load,
+                } = chunk
+                else {
+                    continue; // filtered above; can't happen
+                };
 
-                if chunk.is_new_load {
+                chunk_receiver.loaded.insert((chunk_pos.x(), chunk_pos.z()));
+
+                if is_new_load {
                     mob_load_writer.write(temper_messages::load_chunk_entities::LoadChunkEntities(
-                        chunk.pos,
+                        chunk_pos,
                     ));
                 }
 
-                if let Err(err) = conn.send_raw_packet(chunk.packet_data) {
+                if let Err(err) = conn.send_raw_packet(packet_data) {
                     error!("Failed to send chunk packet: {:?}", err);
                 }
 
-                for entity_tuple in chunk.entities {
+                for entity_tuple in entities {
                     entity_tracker.to_track.push(entity_tuple);
                 }
             }
@@ -175,38 +200,49 @@ pub fn handle(
                 .insert((coordinates.x(), coordinates.z())); // Mark this chunk as in-flight to prevent duplicate generation
 
             state.0.thread_pool.oneshot(move || {
-                let chunk_data = {
-                    let chunk_ref = state_clone
-                        .0
-                        .world
-                        .get_or_generate_chunk(coordinates, Dimension::Overworld)
-                        .expect("Failed to load or generate chunk");
+                // Inner closure so we can use `?` on the three fallible steps
+                // instead of unwinding the whole pool thread on any of them.
+                let prepare = || -> Result<PreparedChunk, String> {
+                    let chunk_data = {
+                        let chunk_ref = state_clone
+                            .0
+                            .world
+                            .get_or_generate_chunk(coordinates, Dimension::Overworld)
+                            .map_err(|err| format!("load or generate failed: {err:?}"))?;
 
-                    (*chunk_ref).clone_without_transient_noise()
+                        (*chunk_ref).clone_without_transient_noise()
+                    };
+
+                    let mut entities = Vec::new();
+                    for kv in chunk_data.entities.iter() {
+                        entities.push((*kv.key(), kv.value().0.to_entity_type().id));
+                    }
+
+                    let packet = ChunkAndLightData::from_chunk(coordinates, &chunk_data)
+                        .map_err(|err| format!("building ChunkAndLightData failed: {err:?}"))?;
+
+                    let packet_data = compress_packet(
+                        &packet,
+                        is_compressed,
+                        &NetEncodeOpts::WithLength,
+                        state_clone.0.config.network_compression_threshold as usize,
+                    )
+                    .map_err(|err| format!("compressing chunk packet failed: {err:?}"))?;
+
+                    Ok(PreparedChunk::Ready {
+                        pos: coordinates,
+                        packet_data,
+                        entities,
+                        is_new_load,
+                    })
                 };
 
-                let mut entities = Vec::new();
-                for kv in chunk_data.entities.iter() {
-                    entities.push((*kv.key(), kv.value().0.to_entity_type().id));
-                }
-
-                let packet = ChunkAndLightData::from_chunk(coordinates, &chunk_data)
-                    .expect("Failed to create ChunkAndLightData");
-
-                let packet_data = compress_packet(
-                    &packet,
-                    is_compressed,
-                    &NetEncodeOpts::WithLength,
-                    state_clone.0.config.network_compression_threshold as usize,
-                )
-                .expect("Failed to compress ChunkAndLightData packet");
-
-                let _ = tx.send(PreparedChunk {
-                    pos: coordinates,
-                    packet_data,
-                    entities,
-                    is_new_load,
+                let message = prepare().unwrap_or_else(|err| {
+                    error!("Chunk {:?} failed to prepare: {}", coordinates, err);
+                    PreparedChunk::Failed { pos: coordinates }
                 });
+
+                let _ = tx.send(message);
             });
         }
     }

--- a/src/game_systems/src/background/src/chunk_unloader.rs
+++ b/src/game_systems/src/background/src/chunk_unloader.rs
@@ -34,6 +34,11 @@ pub fn handle(
         for &(x, z) in &chunk_receiver.dirty {
             visible_chunks.insert(ChunkPos::new(x, z));
         }
+
+        // this protects chunks dispatched to the pool but not yet harvested
+        for &(x, z) in &chunk_receiver.in_flight {
+            visible_chunks.insert(ChunkPos::new(x, z));
+        }
     }
 
     // map all chunks currently in the cache
@@ -42,16 +47,40 @@ pub fn handle(
         all_chunks.insert(entry.key().0);
     }
 
+    // A chunk with live generation jobs also needs its neighbours kept
+    // resident: higher stages read neighbours as snapshots after those
+    // neighbours' own jobs have already completed, so `has_pending_jobs`
+    // alone doesn't protect them.
+    let mut generation_locked = HashSet::new();
+    for chunk_pos in all_chunks.iter() {
+        if state
+            .0
+            .world
+            .chunk_generator
+            .has_pending_jobs(Overworld, *chunk_pos)
+        {
+            for dx in -1..=1 {
+                for dz in -1..=1 {
+                    generation_locked.insert(ChunkPos::new(chunk_pos.x() + dx, chunk_pos.z() + dz));
+                }
+            }
+        }
+    }
+
     let mut unloaded_entries = 0;
-    let mut written_chunks = 0;
+    let mut chunks_to_write = Vec::new();
 
     // unload anything not in the visible/pending set
     // if 0 players are online, visible_chunks is empty, so this should gracefully unload the entire server.
     for chunk_pos in all_chunks.difference(&visible_chunks) {
+        if generation_locked.contains(chunk_pos) {
+            continue;
+        }
+
         if let Some(((pos, dim), chunk)) =
             state.0.world.get_cache().remove(&(*chunk_pos, Overworld))
         {
-            // cancel any pending generation for this chunk
+            // drop this chunk's completed job entries
             state.0.world.chunk_generator.forget_chunk(dim, pos);
 
             // despawn orphaned entities
@@ -70,17 +99,25 @@ pub fn handle(
                 }
             }
 
-            // save state
+            // queue for saving — writes happen off-thread, below
             if chunk.is_dirty() {
-                if let Err(err) = state.0.world.insert_chunk(pos, dim, chunk) {
-                    error!("Failed to write chunk {:?} back to storage: {:?}", pos, err);
-                } else {
-                    written_chunks += 1;
-                }
+                chunks_to_write.push((pos, dim, chunk));
             }
 
             unloaded_entries += 1;
         }
+    }
+
+    let written_chunks = chunks_to_write.len();
+    if written_chunks > 0 {
+        let state_clone = state.clone();
+        state.0.thread_pool.oneshot(move || {
+            for (pos, dim, chunk) in chunks_to_write {
+                if let Err(err) = state_clone.0.world.insert_chunk(pos, dim, chunk) {
+                    error!("Failed to write chunk {:?} back to storage: {:?}", pos, err);
+                }
+            }
+        });
     }
 
     if unloaded_entries > 0 {

--- a/src/game_systems/src/background/src/chunk_unloader.rs
+++ b/src/game_systems/src/background/src/chunk_unloader.rs
@@ -98,22 +98,7 @@ pub fn handle(
                     cmd.entity(entity).despawn();
                 }
             }
-        }
-
-        let cache_keys = state
-            .0
-            .world
-            .get_cache()
-            .iter()
-            .map(|entry| *entry.key())
-            .collect::<Vec<_>>();
-
-        for (pos, dim) in cache_keys {
-            let Some((_, chunk)) = state.0.world.get_cache().remove(&(pos, dim)) else {
-                continue;
-            };
-
-            // queue for saving — writes happen off-thread, below
+            // queue for saving, writes happen off-thread, below
             if chunk.is_dirty() {
                 chunks_to_write.push((pos, dim, chunk));
             }
@@ -136,7 +121,7 @@ pub fn handle(
 
     if unloaded_entries > 0 {
         trace!(
-            "Unloaded {} chunks ({} written to disk). {} chunks remain in cache.",
+            "Unloaded {} chunks ({} queued for write to disk). {} chunks remain in cache.",
             unloaded_entries,
             written_chunks,
             state.0.world.get_cache().len()

--- a/src/game_systems/src/background/src/chunk_unloader.rs
+++ b/src/game_systems/src/background/src/chunk_unloader.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::{Commands, Entity, Has, MessageWriter, Query, Res};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use temper_components::last_chunk_pos::LastChunkPos;
 use temper_components::player::chunk_receiver::ChunkReceiver;
 use temper_components::player::player_marker::PlayerMarker;
@@ -17,34 +17,49 @@ pub fn handle(
     entity_query: Query<(Entity, &LastChunkPos, Has<PlayerMarker>, Has<MobKind>)>,
     mut despawn_mobs: MessageWriter<DespawnMob>,
 ) {
-    // If there are no connected players, unload all cached chunks
-    if query.count() == 0 {
-        let mut removed = 0;
-        let chunk_mapped_entities: HashMap<ChunkPos, Vec<Entity>> = entity_query
-            .iter()
-            .filter(|(_, _, is_player, _)| !is_player)
-            .map(|(entity, last_chunk, _, _)| (last_chunk.0, entity))
-            .fold(HashMap::new(), |mut acc, (chunk_pos, entity)| {
-                acc.entry(chunk_pos).or_insert_with(Vec::new).push(entity);
-                acc
-            });
-        for (pos, entities) in chunk_mapped_entities {
-            let chunk = state
-                .0
-                .world
-                .get_cache()
-                .get(&(pos, Overworld))
-                .expect("Chunk position from entity last chunk pos should exist in cache.");
-            removed += 1;
-            for (entity, _last_chunk, _is_player, is_mob) in entities.iter().map(|entity| {
-                entity_query
-                    .get(*entity)
-                    .expect("Entity from chunk mapped entities should exist in entity query.")
-            }) {
-                trace!(
-                    "Unloading live entity {:?} from chunk {:?} as no players are connected.",
-                    entity, pos
-                );
+    let mut visible_chunks = HashSet::new();
+
+    // gather chunks players can see OR are waiting to see
+    for chunk_receiver in query.iter() {
+        for &(x, z) in &chunk_receiver.loaded {
+            visible_chunks.insert(ChunkPos::new(x, z));
+        }
+
+        // this protects chunks currently being generated/sent
+        for &(x, z) in &chunk_receiver.loading {
+            visible_chunks.insert(ChunkPos::new(x, z));
+        }
+
+        // this protects chunks waiting for block updates
+        for &(x, z) in &chunk_receiver.dirty {
+            visible_chunks.insert(ChunkPos::new(x, z));
+        }
+    }
+
+    // map all chunks currently in the cache
+    let mut all_chunks = HashSet::new();
+    for entry in state.0.world.get_cache().iter() {
+        all_chunks.insert(entry.key().0);
+    }
+
+    let mut unloaded_entries = 0;
+    let mut written_chunks = 0;
+
+    // unload anything not in the visible/pending set
+    // if 0 players are online, visible_chunks is empty, so this should gracefully unload the entire server.
+    for chunk_pos in all_chunks.difference(&visible_chunks) {
+        if let Some(((pos, dim), chunk)) =
+            state.0.world.get_cache().remove(&(*chunk_pos, Overworld))
+        {
+            // cancel any pending generation for this chunk
+            state.0.world.chunk_generator.forget_chunk(dim, pos);
+
+            // despawn orphaned entities
+            for (entity, last_chunk, is_player, is_mob) in entity_query.iter() {
+                if is_player || last_chunk.0 != pos {
+                    continue;
+                }
+
                 if is_mob {
                     despawn_mobs.write(DespawnMob {
                         entity,
@@ -55,91 +70,25 @@ pub fn handle(
                 }
             }
 
-            // Write chunks back to the world storage
+            // save state
             if chunk.is_dirty() {
-                if let Err(err) = state.0.world.insert_chunk(pos, Overworld, chunk.clone()) {
-                    error!(
-                        "Failed to write chunk at position {:?} back to world storage: {:?}",
-                        pos, err
-                    );
-                }
-                continue;
-            }
-        }
-        // Clear the entire cache
-        state.0.world.get_cache().clear();
-        state.0.world.chunk_generator.forget_all();
-        // Log how many chunks were removed
-        if removed > 0 {
-            trace!(
-                "Unloaded {} chunks from cache as there are no connected players.",
-                removed
-            );
-        }
-        return;
-    }
-    let mut all_chunks: HashSet<ChunkPos> = HashSet::new();
-    let mut visible_chunks = HashSet::new();
-    'chunk_iter: for chunk_candidate in state.0.world.get_cache() {
-        let (k, _v) = chunk_candidate.pair();
-        // Track all chunk positions seen in the cache
-        all_chunks.insert(k.0);
-        // Track chunks that are visible to any connected player
-        for chunk_receiver in query.iter() {
-            if chunk_receiver.loaded.contains(&(k.0.x(), k.0.z())) {
-                visible_chunks.insert(k.0);
-                continue 'chunk_iter;
-            }
-        }
-    }
-    let mut unloaded_entries = 0;
-    let mut written_chunks = 0;
-    // The difference is the set of chunks that are in the cache but not visible to any player
-    for chunk_pos in all_chunks.difference(&visible_chunks) {
-        let removed_chunk = state.0.world.get_cache().remove(&(*chunk_pos, Overworld));
-        match removed_chunk {
-            Some(((pos, dim), chunk)) => {
-                state.0.world.chunk_generator.forget_chunk(dim, pos);
-                for (entity, last_chunk, is_player, is_mob) in entity_query.iter() {
-                    if is_player || last_chunk.0 != *chunk_pos {
-                        continue;
-                    }
-
-                    trace!(
-                        "Unloading live entity {:?} from chunk {:?} as it is no longer visible to any player.",
-                        entity, chunk_pos
-                    );
-                    if is_mob {
-                        despawn_mobs.write(DespawnMob {
-                            entity,
-                            remove_from_chunk: false,
-                        });
-                    } else {
-                        cmd.entity(entity).despawn();
-                    }
-                }
-                let dirty = chunk.is_dirty();
-                if dirty {
-                    state
-                        .0
-                        .world
-                        .insert_chunk(pos, dim, chunk)
-                        .expect("Failed to re-insert chunk after unloading from cache.");
+                if let Err(err) = state.0.world.insert_chunk(pos, dim, chunk) {
+                    error!("Failed to write chunk {:?} back to storage: {:?}", pos, err);
+                } else {
                     written_chunks += 1;
                 }
-                unloaded_entries += 1;
             }
-            None => {
-                error!(
-                    "Chunk at position {:?} could not be removed because it does not exist in the cache.",
-                    chunk_pos
-                );
-            }
+
+            unloaded_entries += 1;
         }
     }
-    let remaining_chunks = state.0.world.get_cache().len();
-    trace!(
-        "Unloaded {} chunks from cache ({} written to world). {} chunks remain in cache.",
-        unloaded_entries, written_chunks, remaining_chunks
-    );
+
+    if unloaded_entries > 0 {
+        trace!(
+            "Unloaded {} chunks ({} written to disk). {} chunks remain in cache.",
+            unloaded_entries,
+            written_chunks,
+            state.0.world.get_cache().len()
+        );
+    }
 }

--- a/src/game_systems/src/background/src/world_sync.rs
+++ b/src/game_systems/src/background/src/world_sync.rs
@@ -15,26 +15,24 @@ use temper_permissions::player::PlayerPermission;
 use temper_resources::world_sync_tracker::WorldSyncTracker;
 use temper_state::GlobalStateResource;
 use tracing::error;
+use uuid::Uuid;
 
-pub fn sync_world(
-    player_query: Query<(
-        &Identity,
-        &PlayerAbilities,
-        &GameModeComponent,
-        &Position,
-        &Rotation,
-        &Inventory,
-        &Health,
-        &Hunger,
-        &Experience,
-        &EnderChest,
-        &ActiveEffects,
-        &PlayerPermission,
-    )>,
-    state: Res<GlobalStateResource>,
-    mut last_synced: ResMut<WorldSyncTracker>,
-) {
-    // collect player data in RAM
+type PlayerSaveQuery<'a> = (
+    &'a Identity,
+    &'a PlayerAbilities,
+    &'a GameModeComponent,
+    &'a Position,
+    &'a Rotation,
+    &'a Inventory,
+    &'a Health,
+    &'a Hunger,
+    &'a Experience,
+    &'a EnderChest,
+    &'a ActiveEffects,
+    &'a PlayerPermission,
+);
+
+fn collect_player_data(player_query: &Query<PlayerSaveQuery>) -> Vec<(Uuid, OfflinePlayerData)> {
     let mut players_to_save = Vec::with_capacity(player_query.iter().len());
 
     for (
@@ -68,15 +66,24 @@ pub fn sync_world(
         players_to_save.push((identity.uuid, data));
     }
 
-    // dispatch disk I/O to the thread pool
+    players_to_save
+}
+
+/// Periodic world sync. Disk I/O goes to the thread pool so the schedule isn't
+/// blocked on LMDB, which only permits one writer at a time.
+pub fn sync_world(
+    player_query: Query<PlayerSaveQuery>,
+    state: Res<GlobalStateResource>,
+    mut last_synced: ResMut<WorldSyncTracker>,
+) {
+    let players_to_save = collect_player_data(&player_query);
+
     let state_clone = state.clone();
     state.0.thread_pool.oneshot(move || {
-        // 1. Sync chunks to disk
         if let Err(e) = state_clone.0.world.sync() {
             error!("Failed to sync world chunks to disk: {}", e);
         }
 
-        // 2. Save player data to disk
         for (uuid, data) in players_to_save {
             if let Err(e) = state_clone.0.world.save_player_data(uuid, &data) {
                 error!("Failed to save player data for {}: {}", uuid, e);
@@ -85,4 +92,19 @@ pub fn sync_world(
     });
 
     last_synced.last_synced = std::time::Instant::now();
+}
+
+/// Shutdown flush. Unlike `sync_world`, this writes synchronously: the process
+/// may exit as soon as the shutdown schedule returns, so a pool-dispatched
+/// write could be dropped before it lands.
+pub fn flush_world(player_query: Query<PlayerSaveQuery>, state: Res<GlobalStateResource>) {
+    if let Err(e) = state.0.world.sync() {
+        error!("Failed to sync world chunks to disk on shutdown: {}", e);
+    }
+
+    for (uuid, data) in collect_player_data(&player_query) {
+        if let Err(e) = state.0.world.save_player_data(uuid, &data) {
+            error!("Failed to save player data for {} on shutdown: {}", uuid, e);
+        }
+    }
 }

--- a/src/game_systems/src/background/src/world_sync.rs
+++ b/src/game_systems/src/background/src/world_sync.rs
@@ -14,6 +14,7 @@ use temper_inventories::inventory::Inventory;
 use temper_permissions::player::PlayerPermission;
 use temper_resources::world_sync_tracker::WorldSyncTracker;
 use temper_state::GlobalStateResource;
+use tracing::error;
 
 pub fn sync_world(
     player_query: Query<(
@@ -33,12 +34,8 @@ pub fn sync_world(
     state: Res<GlobalStateResource>,
     mut last_synced: ResMut<WorldSyncTracker>,
 ) {
-    // if state.0.shut_down.load(std::sync::atomic::Ordering::Relaxed) {
-    //     return;
-    // }
-
-    // Always schedule a sync; frequency is handled by the schedule period.
-    state.0.world.sync().expect("Failed to sync world");
+    // collect player data in RAM
+    let mut players_to_save = Vec::with_capacity(player_query.iter().len());
 
     for (
         identity,
@@ -68,12 +65,24 @@ pub fn sync_world(
             active_effects: active_effects.clone(),
             permissions: permissions.clone(),
         };
-        state
-            .0
-            .world
-            .save_player_data(identity.uuid, &data)
-            .expect("Failed to save player data");
+        players_to_save.push((identity.uuid, data));
     }
+
+    // dispatch disk I/O to the thread pool
+    let state_clone = state.clone();
+    state.0.thread_pool.oneshot(move || {
+        // 1. Sync chunks to disk
+        if let Err(e) = state_clone.0.world.sync() {
+            error!("Failed to sync world chunks to disk: {}", e);
+        }
+
+        // 2. Save player data to disk
+        for (uuid, data) in players_to_save {
+            if let Err(e) = state_clone.0.world.save_player_data(uuid, &data) {
+                error!("Failed to save player data for {}: {}", uuid, e);
+            }
+        }
+    });
 
     last_synced.last_synced = std::time::Instant::now();
 }

--- a/src/game_systems/src/lib.rs
+++ b/src/game_systems/src/lib.rs
@@ -249,7 +249,7 @@ pub fn register_schedules(
     );
     mobs::register_save_systems(shutdown_schedule);
     shutdown_schedule
-        .add_systems(background::world_sync::sync_world.in_set(ShutdownPhase::FlushWorld));
+        .add_systems(background::world_sync::flush_world.in_set(ShutdownPhase::FlushWorld));
     shutdown_schedule
         .add_systems(shutdown::send_shutdown_packet::handle.in_set(ShutdownPhase::ShutdownPackets));
 

--- a/src/game_systems/src/player/src/chunk_calculator.rs
+++ b/src/game_systems/src/player/src/chunk_calculator.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{MessageReader, Query, Res};
 use bevy_math::IVec2;
+use std::collections::HashSet;
 use temper_components::player::chunk_receiver::ChunkReceiver;
 use temper_components::player::client_information::ClientInformationComponent;
 use temper_components::player::position::Position;
@@ -19,46 +20,54 @@ pub fn handle(
             Err(_) => {
                 warn!("Player does not exist, skipping chunk calculation");
                 continue;
-            } // Skip if the player does not exist
+            }
         };
 
         let server_render_distance = state.0.config.chunk_render_distance as i32;
         let client_view_distance = i32::from(client_info.view_distance);
         let radius = server_render_distance.min(client_view_distance);
         let player_chunk = ChunkPos::from(position.coords);
+        let player_vec = IVec2::new(player_chunk.x(), player_chunk.z());
 
-        let mut queued_chunks = Vec::new();
-
-        // Add all chunks within the radius to the loading list if not already loaded
+        // 1. Build the absolute set of chunks the player currently needs
+        let mut needed_set = HashSet::new();
         for x in player_chunk.x() - radius..=player_chunk.x() + radius {
             for z in player_chunk.z() - radius..=player_chunk.z() + radius {
-                let chunk_coords = (x, z);
-                if !chunk_receiver.loaded.contains(&chunk_coords) {
-                    queued_chunks.push(chunk_coords);
-                }
+                needed_set.insert((x, z));
             }
         }
 
-        // Sort loading list to prioritize closer chunks
-        queued_chunks.sort_by_key(|(x, z)| {
-            let as_vec = IVec2::new(*x, *z);
-            as_vec.chebyshev_distance(IVec2::new(player_chunk.x(), player_chunk.z()))
-        });
-
-        for coords in queued_chunks {
-            chunk_receiver.loading.push_back(coords);
+        // 2. Unload chunks that are currently loaded but fall outside the new radius
+        let mut to_unload = Vec::new();
+        for &loaded_chunk in &chunk_receiver.loaded {
+            if !needed_set.contains(&loaded_chunk) {
+                to_unload.push(loaded_chunk);
+            }
+        }
+        for chunk in to_unload {
+            chunk_receiver.loaded.remove(&chunk);
+            chunk_receiver.unloading.push_back(chunk);
         }
 
-        // Unload chunks that are outside the radius
+        // 3. Purge the queues of chunks the player ran away from before they could generate
+        chunk_receiver.loading.retain(|c| needed_set.contains(c));
+        chunk_receiver.dirty.retain(|c| needed_set.contains(c));
 
-        for loaded_chunk in chunk_receiver.loaded.clone() {
-            let vec = IVec2::new(loaded_chunk.0, loaded_chunk.1);
-            let dx = IVec2::new(player_chunk.x(), player_chunk.z()).chebyshev_distance(vec);
-            if dx > radius as u32
-                && let Some(pos) = chunk_receiver.loaded.take(&loaded_chunk)
+        // 4. Queue genuinely new chunks, preventing duplicates
+        for &chunk_coords in &needed_set {
+            if !chunk_receiver.loaded.contains(&chunk_coords)
+                && !chunk_receiver.loading.contains(&chunk_coords)
+                && !chunk_receiver.dirty.contains(&chunk_coords)
+                && !chunk_receiver.in_flight.contains(&chunk_coords)
             {
-                chunk_receiver.unloading.push_back(pos);
+                chunk_receiver.loading.push_back(chunk_coords);
             }
         }
+
+        // 5. Re-sort the pending queue so the threads always generate the closest chunks first
+        chunk_receiver
+            .loading
+            .make_contiguous()
+            .sort_by_key(|&(x, z)| IVec2::new(x, z).chebyshev_distance(player_vec));
     }
 }

--- a/src/game_systems/tests/mobs/chunk_visibility_lifecycle.rs
+++ b/src/game_systems/tests/mobs/chunk_visibility_lifecycle.rs
@@ -19,7 +19,23 @@ use temper_entities::markers::{HasCollisions, HasGravity, HasWaterDrag};
 use temper_entities::{FoxBundle, PigBundle};
 use temper_messages::chunk_calc::ChunkCalc;
 use temper_messages::load_chunk_entities::LoadChunkEntities;
-use temper_state::create_test_state;
+use temper_state::{GlobalStateResource, create_test_state};
+
+/// `chunk_unloader` dispatches storage writes to the thread pool, so a chunk
+/// evicted from the cache is not immediately readable from storage. Poll until
+/// the write lands rather than assuming it already has.
+pub fn wait_for_saved_chunk(
+    state: &GlobalStateResource,
+    pos: ChunkPos,
+) -> temper_world::RefChunk<'_> {
+    for _ in 0..200 {
+        if let Ok(chunk) = state.0.world.get_chunk(pos, Dimension::Overworld) {
+            return chunk;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    panic!("chunk {pos:?} never reached storage after unload");
+}
 
 fn emit_chunk_calc_for(entity: Entity) -> impl FnMut(MessageWriter<ChunkCalc>) {
     move |mut writer: MessageWriter<ChunkCalc>| {
@@ -156,39 +172,14 @@ fn multiple_entities_in_one_chunk_reload_together_when_player_returns() {
         "pig should unload when the player leaves the chunk"
     );
 
-    let cached_chunk = state
-        .0
-        .world
-        .get_cache()
-        .get(&(chunk, Dimension::Overworld))
-        .expect("dirty chunk should stay cached until world sync");
-    assert!(
-        cached_chunk.is_dirty(),
-        "unloaded dirty chunks should wait for the background sync pass"
-    );
-    assert_eq!(
-        cached_chunk.entities.len(),
-        2,
-        "both entities should be retained in the chunk"
-    );
-    drop(cached_chunk);
-
-    state
-        .0
-        .world
-        .sync()
-        .expect("dirty chunk should sync before restart-style reload");
-    let saved_chunk = state
-        .0
-        .world
-        .get_chunk(chunk, Dimension::Overworld)
-        .expect("saved chunk should exist");
-    assert_eq!(
-        saved_chunk.entities.len(),
-        2,
-        "both entities should be persisted"
-    );
-    drop(saved_chunk);
+    {
+        let saved_chunk = wait_for_saved_chunk(&state, chunk);
+        assert_eq!(
+            saved_chunk.entities.len(),
+            2,
+            "both entities should be persisted"
+        );
+    }
     state.0.world.get_cache().clear();
 
     {

--- a/src/game_systems/tests/mobs/entity_persistence.rs
+++ b/src/game_systems/tests/mobs/entity_persistence.rs
@@ -146,8 +146,11 @@ fn load_cows_into_replacement_ecs(
 fn run_registered_shutdown_schedule(world: &mut World) {
     let mut timed = Scheduler::new();
     let mut shutdown_schedule = Schedule::default();
-    let state = create_test_state();
-    temper_game_systems::register_schedules(&mut timed, &mut shutdown_schedule, state.0.0);
+    let state = world
+        .get_resource::<GlobalStateResource>()
+        .expect("world should have a state resource")
+        .clone();
+    temper_game_systems::register_schedules(&mut timed, &mut shutdown_schedule, state.0);
     shutdown_schedule.run(world);
 }
 

--- a/src/game_systems/tests/mobs/player_distance_reload.rs
+++ b/src/game_systems/tests/mobs/player_distance_reload.rs
@@ -20,7 +20,24 @@ use temper_entities::markers::entity_types::Fox;
 use temper_entities::markers::{HasCollisions, HasGravity, HasWaterDrag};
 use temper_messages::chunk_calc::ChunkCalc;
 use temper_messages::load_chunk_entities::LoadChunkEntities;
+use temper_state::GlobalStateResource;
 use temper_state::create_test_state;
+
+/// `chunk_unloader` dispatches storage writes to the thread pool, so a chunk
+/// evicted from the cache is not immediately readable from storage. Poll until
+/// the write lands rather than assuming it already has.
+pub fn wait_for_saved_chunk(
+    state: &GlobalStateResource,
+    pos: ChunkPos,
+) -> temper_world::RefChunk<'_> {
+    for _ in 0..200 {
+        if let Ok(chunk) = state.0.world.get_chunk(pos, Dimension::Overworld) {
+            return chunk;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    panic!("chunk {pos:?} never reached storage after unload");
+}
 
 fn emit_chunk_calc_for(entity: Entity) -> impl FnMut(MessageWriter<ChunkCalc>) {
     move |mut writer: MessageWriter<ChunkCalc>| {
@@ -132,34 +149,16 @@ fn player_can_unload_entities_by_moving_away_and_reload_them_after_returning() {
         live_foxes, 0,
         "fox should despawn when its chunk is unloaded"
     );
-    let cached_chunk = state
-        .0
-        .world
-        .get_cache()
-        .get(&(fox_chunk, Dimension::Overworld))
-        .expect("dirty fox chunk should stay cached until world sync");
     assert!(
-        cached_chunk.is_dirty(),
-        "unloaded dirty chunks should wait for the background sync pass"
-    );
-    assert_eq!(
-        cached_chunk.entities.len(),
-        1,
-        "only the test fox should be retained in the chunk"
-    );
-    drop(cached_chunk);
-
-    state
-        .0
-        .world
-        .sync()
-        .expect("dirty fox chunk should sync before restart-style reload");
-    {
-        let saved_chunk = state
+        !state
             .0
             .world
-            .get_chunk(fox_chunk, Dimension::Overworld)
-            .expect("saved fox chunk should be readable from storage");
+            .get_cache()
+            .contains_key(&(fox_chunk, Dimension::Overworld)),
+        "fox chunk should be removed from cache after unload"
+    );
+    {
+        let saved_chunk = wait_for_saved_chunk(&state, fox_chunk);
         assert_eq!(
             saved_chunk.entities.len(),
             1,

--- a/src/world/Cargo.toml
+++ b/src/world/Cargo.toml
@@ -25,6 +25,7 @@ gen-scheduler = { path = "./gen/scheduler" }
 world-gen = { path = "./gen" }
 world-db = { path = "./db" }
 temper-core = { workspace = true }
+crossbeam-channel = {workspace = true }
 
 
 

--- a/src/world/gen/scheduler/src/job.rs
+++ b/src/world/gen/scheduler/src/job.rs
@@ -54,7 +54,7 @@ pub struct AtomicJobState {
 }
 
 impl AtomicJobState {
-    pub const fn new(state: JobState) -> Self {
+    pub fn new(state: JobState) -> Self {
         Self {
             state: AtomicU8::new(state as u8),
         }
@@ -123,6 +123,46 @@ impl JobEntry {
             dependents: Mutex::new(Vec::new()),
             interested_requests: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Like `new`, but used while a job's real dependency count is still
+    /// being discovered. Starts with one placeholder dependency so nothing
+    /// can mark it Ready mid-registration; `register_job` clears it once
+    /// every real dependency has been wired up.
+    pub fn new_pending(key: JobKey) -> Self {
+        Self {
+            key,
+            state: AtomicJobState::new(JobState::Waiting),
+            remaining_dependencies: AtomicUsize::new(1),
+            dependents: Mutex::new(Vec::new()),
+            interested_requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Registers `dependent` to be notified when this job completes.
+    /// Returns `true` if this job had *already* completed before this call
+    /// (in which case `mark_complete` already ran and will never notify
+    /// `dependent` — the caller must treat the dependency as satisfied
+    /// immediately instead of waiting for a notification).
+    pub fn add_dependent_or_already_complete(&self, dependent: JobKey) -> bool {
+        let mut dependents = self.dependents.lock().expect("dependent list poisoned");
+        if self.state.load() == JobState::Complete {
+            return true;
+        }
+        if !dependents.contains(&dependent) {
+            dependents.push(dependent);
+        }
+        false
+    }
+
+    /// Marks the job complete and, if this call is the one that actually
+    /// did it, returns the dependents to notify.
+    pub fn complete_and_take_dependents(&self) -> Option<Vec<JobKey>> {
+        let dependents = self.dependents.lock().expect("dependent list poisoned");
+        if !self.state.mark_complete_once() {
+            return None;
+        }
+        Some(dependents.clone())
     }
 
     pub fn add_dependent(&self, dependent: JobKey) {

--- a/src/world/gen/scheduler/src/state.rs
+++ b/src/world/gen/scheduler/src/state.rs
@@ -66,15 +66,11 @@ impl SchedulerState {
     }
 
     pub fn mark_complete(&self, key: JobKey) -> Result<(), SchedulerError> {
-        let _registration_lock = self
-            .registration_lock
-            .lock()
-            .expect("registration lock poisoned");
         let job = self.jobs.get(&key).ok_or(SchedulerError::UnknownJob(key))?;
 
-        if !job.state.mark_complete_once() {
+        let Some(dependents) = job.complete_and_take_dependents() else {
             return Ok(());
-        }
+        };
 
         for request_id in job.interested_requests() {
             let Some(request) = self.requests.get(&request_id) else {
@@ -83,7 +79,7 @@ impl SchedulerState {
             request.wake();
         }
 
-        for dependent_key in job.dependents() {
+        for dependent_key in dependents {
             let Some(dependent) = self.jobs.get(&dependent_key) else {
                 continue;
             };
@@ -171,23 +167,24 @@ impl SchedulerState {
         let stage_spec = generator
             .stage_spec(key.stage)
             .ok_or(SchedulerError::UnknownStage(key))?;
-        let dependency_keys = dependency_keys(key, stage_spec.dependencies);
-        let mut remaining_dependencies = 0;
 
-        for dependency_key in dependency_keys {
-            let dependency = self.register_job(generator, request, dependency_key, visited)?;
-            dependency.add_dependent(key);
-
-            if dependency.state.load() != JobState::Complete {
-                remaining_dependencies += 1;
-            }
-        }
-
-        let job = Arc::new(JobEntry::new(key, remaining_dependencies));
+        let job = Arc::new(JobEntry::new_pending(key));
         self.jobs.insert(key, Arc::clone(&job));
         job.add_interested_request(request.id);
 
-        if remaining_dependencies == 0 {
+        let dependency_keys = dependency_keys(key, stage_spec.dependencies);
+
+        for dependency_key in dependency_keys {
+            let dependency = self.register_job(generator, request, dependency_key, visited)?;
+
+            if !dependency.add_dependent_or_already_complete(key) {
+                job.remaining_dependencies.fetch_add(1, AcqRel);
+            }
+        }
+
+        // Clear the placeholder dependency. If nothing real is outstanding
+        // either, this is the moment the job becomes ready.
+        if job.remaining_dependencies.fetch_sub(1, AcqRel) == 1 && job.state.mark_ready() {
             self.publish_ready(&job);
         }
 

--- a/src/world/gen/scheduler/src/state.rs
+++ b/src/world/gen/scheduler/src/state.rs
@@ -97,6 +97,14 @@ impl SchedulerState {
         self.requests.remove(&request);
     }
 
+    pub fn has_pending_jobs(&self, dimension: Dimension, pos: ChunkPos) -> bool {
+        (0..=GenStage::FULL.raw()).any(|stage| {
+            self.jobs
+                .get(&JobKey::new(dimension, pos, GenStage::new(stage)))
+                .is_some_and(|job| job.state.load() != JobState::Complete)
+        })
+    }
+
     pub fn forget_chunk(&self, dimension: Dimension, pos: ChunkPos) {
         let _registration_lock = self
             .registration_lock
@@ -138,6 +146,23 @@ impl SchedulerState {
 
     pub fn get_job(&self, key: JobKey) -> Option<Arc<JobEntry>> {
         self.jobs.get(&key).map(|job| Arc::clone(&job))
+    }
+
+    /// Releases a job that failed mid-run so it doesn't sit in `Running`
+    /// forever, and wakes anything waiting on it so those callers can
+    /// re-evaluate instead of sleeping indefinitely.
+    pub fn fail_job(&self, key: JobKey) {
+        let Some(job) = self.jobs.get(&key) else {
+            return;
+        };
+
+        job.state.mark_failed();
+
+        for request_id in job.interested_requests() {
+            if let Some(request) = self.requests.get(&request_id) {
+                request.wake();
+            }
+        }
     }
 
     pub fn next_request_id(&self) -> RequestId {

--- a/src/world/gen/src/selector.rs
+++ b/src/world/gen/src/selector.rs
@@ -4,9 +4,11 @@ use gen_core::ChunkGenerator;
 
 pub fn generator_from_name(name: &str, seed: u64) -> Option<Arc<dyn ChunkGenerator>> {
     match name.trim().to_ascii_lowercase().as_str() {
-        _ if seed == 0x43f6c73858579990 => Some(Arc::new(skyblock::SkyblockGenerator::new(seed))),
         "normal" => Some(Arc::new(normal::NormalGenerator::new(seed))),
+        "skyblock" => Some(Arc::new(skyblock::SkyblockGenerator::new(seed))),
         "superflat" => Some(Arc::new(superflat::SuperflatGenerator::new(seed))),
+        // Easter egg: this seed forces skyblock regardless of configured name.
+        _ if seed == 0x43f6c73858579990 => Some(Arc::new(skyblock::SkyblockGenerator::new(seed))),
         _ => None,
     }
 }
@@ -37,5 +39,13 @@ mod tests {
 
         assert!(generator.is_some());
         assert_eq!(generator.unwrap().id().as_str(), "normal");
+    }
+
+    #[test]
+    fn selects_skyblock_generator_works_from_name() {
+        let generator = generator_from_name("skyblock", 0);
+
+        assert!(generator.is_some());
+        assert_eq!(generator.unwrap().id().as_str(), "skyblock");
     }
 }

--- a/src/world/src/db_wrap.rs
+++ b/src/world/src/db_wrap.rs
@@ -29,6 +29,11 @@ impl ChunkStore {
     }
 
     pub fn ensure_chunk(&self, pos: ChunkPos, dimension: Dimension) -> Result<(), WorldError> {
+        // check cache first to avoid nuking io
+        if self.cache.contains_key(&(pos, dimension)) {
+            return Ok(());
+        }
+
         if self.chunk_exists(pos, dimension)? {
             return Ok(());
         }

--- a/src/world/src/generation.rs
+++ b/src/world/src/generation.rs
@@ -69,12 +69,13 @@ impl WorldChunkGenerator {
             }
 
             if let Some(claimed) = self.scheduler.claim_next_for_request(&request) {
-                if !chunk_has_stage(
+                let already = chunk_has_stage(
                     chunks,
                     claimed.key.dimension,
                     claimed.key.pos,
                     claimed.key.stage,
-                )? {
+                )?;
+                if !already {
                     if let Err(err) = self.run_stage(chunks, claimed.key) {
                         // never leave a claimed job stuck in Running since
                         // everything waiting on it would block forever.
@@ -149,11 +150,7 @@ impl WorldChunkGenerator {
             ))
             .map_err(generation_error)?;
         target.stage = key.stage.raw();
-        if key.stage == self.generator.final_stage() {
-            target.clear_dirty();
-        } else {
-            target.mark_dirty();
-        }
+        target.mark_dirty();
 
         Ok(())
     }
@@ -230,97 +227,4 @@ fn scheduler_error(err: SchedulerError) -> WorldError {
 
 fn generation_error(err: GenerationError) -> WorldError {
     WorldError::WorldGenerationError(err.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use gen_core::{ChunkGenerator, GeneratorId, StageDependencies};
-    use temper_core::block_state_id::BlockStateId;
-    use temper_core::dimension::Dimension;
-    use temper_core::pos::{ChunkBlockPos, ChunkPos};
-    use temper_macros::block;
-    use temper_storage::lmdb::StorageBackend;
-    use tempfile::TempDir;
-    use wyhash::WyHasherBuilder;
-
-    use crate::ChunkStore;
-
-    use super::*;
-
-    struct TestGenerator;
-
-    impl ChunkGenerator for TestGenerator {
-        fn id(&self) -> GeneratorId {
-            GeneratorId::new("test")
-        }
-
-        fn final_stage(&self) -> GenStage {
-            GenStage::SURFACE
-        }
-
-        fn stage_spec(&self, stage: GenStage) -> Option<StageSpec> {
-            match stage {
-                GenStage::EMPTY => Some(StageSpec::new(
-                    GenStage::EMPTY,
-                    "empty",
-                    StageDependencies::NONE,
-                )),
-                GenStage::SURFACE => Some(StageSpec::new(
-                    GenStage::SURFACE,
-                    "surface",
-                    StageDependencies::only_own(GenStage::EMPTY),
-                )),
-                _ => None,
-            }
-        }
-
-        fn advance_stage(&self, input: StageInput<'_>) -> Result<(), GenerationError> {
-            if input.stage == GenStage::SURFACE {
-                input
-                    .target
-                    .set_block(ChunkBlockPos::new(0, 64, 0), block!("stone"));
-            }
-            Ok(())
-        }
-    }
-
-    fn test_store() -> (ChunkStore, TempDir) {
-        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
-        let storage =
-            StorageBackend::initialize(Some(temp_dir.path().to_path_buf()), 1024 * 1024 * 1024)
-                .expect("storage should initialize");
-
-        (
-            ChunkStore::new(storage, false, WyHasherBuilder::default()),
-            temp_dir,
-        )
-    }
-
-    #[test]
-    fn generated_final_chunks_are_clean_until_modified() {
-        let (store, _temp_dir) = test_store();
-        let generator = WorldChunkGenerator::new(Arc::new(TestGenerator));
-        let pos = ChunkPos::new(0, 0);
-
-        generator
-            .generate(&store, Dimension::Overworld, pos)
-            .expect("chunk should generate");
-
-        let mut chunk = store
-            .get_chunk_mut(pos, Dimension::Overworld)
-            .expect("generated chunk should be cached");
-        assert_eq!(chunk.stage, GenStage::SURFACE.raw());
-        assert!(
-            !chunk.is_dirty(),
-            "completed generated chunks should not require storage writes"
-        );
-
-        chunk.set_block(ChunkBlockPos::new(1, 64, 1), block!("gold_block"));
-        assert!(
-            chunk.is_dirty(),
-            "gameplay edits should still mark generated chunks dirty"
-        );
-    }
 }

--- a/src/world/src/generation.rs
+++ b/src/world/src/generation.rs
@@ -1,4 +1,6 @@
+use crossbeam_channel::RecvTimeoutError;
 use std::sync::Arc;
+use std::time::Duration;
 
 use gen_core::{
     ChunkGenerator, GenStage, GenerationError, StageInput, StageNeighbor, StageNeighborhood,
@@ -69,7 +71,12 @@ impl WorldChunkGenerator {
                     claimed.key.pos,
                     claimed.key.stage,
                 )? {
-                    self.run_stage(chunks, claimed.key)?;
+                    if let Err(err) = self.run_stage(chunks, claimed.key) {
+                        // never leave a claimed job stuck in Running since
+                        // everything waiting on it would block forever.
+                        self.scheduler.fail_job(claimed.key);
+                        break Err(err);
+                    }
                 }
 
                 self.scheduler
@@ -78,15 +85,32 @@ impl WorldChunkGenerator {
                 continue;
             }
 
-            if wake_receiver.recv().is_err() {
-                break Err(WorldError::WorldGenerationError(
-                    "chunk generation request closed before the target completed".to_string(),
-                ));
+            // poll rather than block indefinitely: a dependency may have
+            // failed or been forgotten, in which case no wake is coming.
+            match wake_receiver.recv_timeout(Duration::from_millis(50)) {
+                Ok(()) => continue,
+                Err(RecvTimeoutError::Timeout) => {
+                    if self.scheduler.get_job(target).is_none() {
+                        break Err(WorldError::WorldGenerationError(format!(
+                            "generation jobs for {pos:?} were dropped while waiting"
+                        )));
+                    }
+                    continue;
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    break Err(WorldError::WorldGenerationError(
+                        "chunk generation request closed before the target completed".to_string(),
+                    ));
+                }
             }
         };
 
         self.scheduler.unregister_request(request.id);
         result
+    }
+
+    pub fn has_pending_jobs(&self, dimension: Dimension, pos: ChunkPos) -> bool {
+        self.scheduler.has_pending_jobs(dimension, pos)
     }
 
     pub fn forget_chunk(&self, dimension: Dimension, pos: ChunkPos) {


### PR DESCRIPTION
Found cause of big world gen freezes while flying around: synchronous LMDB writes in chunk_unloader::handle, running inline in the chunk_gc schedule. Confirmed empirically: commenting out the insert_chunk call made the freeze disappear entirely.

Fixes applied
1. Scheduler lock contention (gen-scheduler)
2. Blocking tick thread (chunk_sending.rs)
4. In-flight tracking (ChunkReceiver)
5. Async chunk writes (chunk_unloader.rs) - the big freeze fix
6. Async world sync (world_sync.rs)
7. Recoverable worker failures (chunk_sending.rs)
8. Stuck jobs and unbounded waits (generation.rs, state.rs)
9. Neighbor eviction race (chunk_unloader.rs)
10. Cache check in ensure_chunk (db_wrap.rs)

Outstanding things:
has_pending_jobs check isn't atomic with cache removal. This is narrowed, not closed.
no online players fast path was removed, the old cache.clear() + early return was O(1); now always O(cache size).