### PR TITLE
Making entity IDs their own component

### DIFF
--- a/src/components/src/entity_identity.rs
+++ b/src/components/src/entity_identity.rs
@@ -4,11 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Identity component for entities in the game world, including players and non-player entities (mobs, items, etc.).
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct Identity {
-    /// Network entity ID used in packets.
-    /// Must be unique across all entities in the server.
-    /// For players, this is generally the first 4 bytes of the player's UUID, unless multiple
-    /// players have the same UUID (eg. offline mode) in which case it will be random.
-    pub entity_id: i32,
 
     /// Unique identifier for this entity.
     /// Generated randomly for each spawned entity.
@@ -27,7 +22,6 @@ impl Identity {
     /// The UUID is randomly generated.
     pub fn new(name: Option<String>) -> Self {
         Self {
-            entity_id: rand::random(),
             uuid: uuid::Uuid::new_v4(),
             name,
         }
@@ -36,7 +30,6 @@ impl Identity {
     /// Creates an entity identity with a specific UUID (for loading from disk).
     pub fn with_uuid(uuid: uuid::Uuid, name: Option<String>) -> Self {
         Self {
-            entity_id: rand::random(),
             uuid,
             name,
         }

--- a/src/components/src/entity_identity.rs
+++ b/src/components/src/entity_identity.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Identity component for entities in the game world, including players and non-player entities (mobs, items, etc.).
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct Identity {
-
     /// Unique identifier for this entity.
     /// Generated randomly for each spawned entity.
     /// For players, this is the full UUID from Mojang's authentication system.
@@ -29,10 +28,7 @@ impl Identity {
 
     /// Creates an entity identity with a specific UUID (for loading from disk).
     pub fn with_uuid(uuid: uuid::Uuid, name: Option<String>) -> Self {
-        Self {
-            uuid,
-            name,
-        }
+        Self { uuid, name }
     }
 }
 

--- a/src/components/src/game_id.rs
+++ b/src/components/src/game_id.rs
@@ -3,12 +3,10 @@ use std::sync::atomic::AtomicI32;
 use std::sync::LazyLock;
 use temper_codec::net_types::var_int::VarInt;
 
-static ID_COUNTER: LazyLock<AtomicI32> = LazyLock::new(|| {
-    AtomicI32::new(rand::random::<i32>())
-});
+static ID_COUNTER: LazyLock<AtomicI32> = LazyLock::new(|| AtomicI32::new(rand::random::<i32>()));
 
 /// Unique id for each entity for a session/instance. This is how the client tracks entities in game
-#[derive(Component, Copy, Clone)]
+#[derive(Component, Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Debug)]
 pub struct GameID(i32);
 
 impl Default for GameID {
@@ -21,7 +19,7 @@ impl GameID {
     pub fn get(&self) -> VarInt {
         self.0.into()
     }
-    
+
     pub fn new() -> Self {
         // Wraps on overflow so no worries there
         GameID(ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst))

--- a/src/components/src/game_id.rs
+++ b/src/components/src/game_id.rs
@@ -1,0 +1,25 @@
+use bevy_ecs::prelude::Component;
+use std::sync::atomic::AtomicI32;
+use temper_codec::net_types::var_int::VarInt;
+
+static ID_COUNTER: AtomicI32 = AtomicI32::new(i32::MIN);
+
+/// Unique id for each entity for a session/instance. This is how the client tracks entities in game
+#[derive(Component, Copy, Clone)]
+pub struct GameID(i32);
+
+impl Default for GameID {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameID {
+    pub fn get(&self) -> VarInt {
+        self.0.into()
+    }
+    
+    pub fn new() -> Self {
+        GameID(ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
+    }
+}

--- a/src/components/src/game_id.rs
+++ b/src/components/src/game_id.rs
@@ -1,8 +1,11 @@
 use bevy_ecs::prelude::Component;
 use std::sync::atomic::AtomicI32;
+use std::sync::LazyLock;
 use temper_codec::net_types::var_int::VarInt;
 
-static ID_COUNTER: AtomicI32 = AtomicI32::new(i32::MIN);
+static ID_COUNTER: LazyLock<AtomicI32> = LazyLock::new(|| {
+    AtomicI32::new(rand::random::<i32>())
+});
 
 /// Unique id for each entity for a session/instance. This is how the client tracks entities in game
 #[derive(Component, Copy, Clone)]
@@ -20,6 +23,7 @@ impl GameID {
     }
     
     pub fn new() -> Self {
+        // Wraps on overflow so no worries there
         GameID(ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
     }
 }

--- a/src/components/src/lib.rs
+++ b/src/components/src/lib.rs
@@ -8,6 +8,7 @@ pub mod player;
 // Core entity components based on temper-data
 pub mod bossbar;
 pub mod combat;
+pub mod game_id;
 pub mod last_chunk_pos;
 pub mod last_synced_position;
 pub mod metadata;
@@ -15,7 +16,6 @@ pub mod mob_ai;
 pub mod pathfinder;
 pub mod physical;
 pub mod spawn;
-pub mod game_id;
 
 // Interaction components re-exports
 pub use interaction::{Door, InteractableBlock, InteractionCooldown, Toggleable};

--- a/src/components/src/lib.rs
+++ b/src/components/src/lib.rs
@@ -15,6 +15,7 @@ pub mod mob_ai;
 pub mod pathfinder;
 pub mod physical;
 pub mod spawn;
+pub mod game_id;
 
 // Interaction components re-exports
 pub use interaction::{Door, InteractableBlock, InteractionCooldown, Toggleable};

--- a/src/components/src/player/player_bundle.rs
+++ b/src/components/src/player/player_bundle.rs
@@ -1,5 +1,6 @@
 use crate::bounds::CollisionBounds;
 use crate::entity_identity::Identity;
+use crate::game_id::GameID;
 use crate::player::bossbar_sender::BossbarSender;
 use crate::player::chunk_receiver::ChunkReceiver;
 use crate::player::entity_tracker::EntityTracker;
@@ -20,7 +21,6 @@ use crate::{
 use bevy_ecs::prelude::Bundle;
 use temper_inventories::{hotbar::Hotbar, inventory::Inventory};
 use temper_permissions::player::PlayerPermission;
-use crate::game_id::GameID;
 
 /// A Bevy Bundle containing all components required for a player entity.
 /// This groups all 17+ components into a single, spawnable unit.

--- a/src/components/src/player/player_bundle.rs
+++ b/src/components/src/player/player_bundle.rs
@@ -20,6 +20,7 @@ use crate::{
 use bevy_ecs::prelude::Bundle;
 use temper_inventories::{hotbar::Hotbar, inventory::Inventory};
 use temper_permissions::player::PlayerPermission;
+use crate::game_id::GameID;
 
 /// A Bevy Bundle containing all components required for a player entity.
 /// This groups all 17+ components into a single, spawnable unit.
@@ -27,6 +28,7 @@ use temper_permissions::player::PlayerPermission;
 pub struct PlayerBundle {
     // Identity
     pub identity: Identity,
+    pub game_id: GameID,
 
     // Core State
     pub abilities: PlayerAbilities,

--- a/src/default_commands/src/op.rs
+++ b/src/default_commands/src/op.rs
@@ -154,7 +154,6 @@ mod tests {
 
     fn identity(name: &str) -> Identity {
         Identity {
-            entity_id: 0,
             uuid: uuid::Uuid::new_v4(),
             name: Some(name.to_string()),
         }

--- a/src/entities/src/mob_definition.rs
+++ b/src/entities/src/mob_definition.rs
@@ -138,6 +138,8 @@ macro_rules! define_mob {
                 #[serde(skip)]
                 pub $runtime_field: $runtime_ty,
             )*
+            #[serde(skip)]
+            pub game_id: temper_components::game_id::GameID,
         }
 
         impl $bundle {
@@ -159,6 +161,7 @@ macro_rules! define_mob {
                     $(
                         $runtime_field: <$runtime_ty>::default(),
                     )*
+                    game_id: temper_components::game_id::GameID::new()
                 }
             }
 
@@ -243,6 +246,7 @@ macro_rules! define_mob {
                     $(
                         $runtime_field: <$runtime_ty>::default(),
                     )*
+                    game_id: bundle.game_id,
                 }
             }
 
@@ -262,6 +266,7 @@ macro_rules! define_mob {
                     $(
                         $runtime_field: <$runtime_ty>::default(),
                     )*
+                    game_id: temper_components::game_id::GameID::new(),
                 }
             }
 

--- a/src/game_systems/src/background/src/connection_killer.rs
+++ b/src/game_systems/src/background/src/connection_killer.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{Commands, Entity, MessageWriter, Query, Res};
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::offline_player_data::OfflinePlayerData;
 use temper_components::player::position::Position;
 use temper_components::player::rotation::Rotation;
@@ -18,7 +19,6 @@ use temper_permissions::player::PlayerPermission;
 use temper_state::GlobalStateResource;
 use temper_text::TextComponent;
 use tracing::{debug, info, trace, warn};
-use temper_components::game_id::GameID;
 
 // This type alias defines all the components of a "full" player
 type PlayerCacheQuery<'a> = (
@@ -36,7 +36,7 @@ type PlayerCacheQuery<'a> = (
     &'a EnderChest,
     &'a ActiveEffects,
     &'a PlayerPermission,
-    &'a GameID
+    &'a GameID,
 );
 
 pub fn connection_killer(
@@ -69,7 +69,7 @@ pub fn connection_killer(
             echest,
             effects,
             permissions,
-            game_id
+            game_id,
         )) = full_player_query.get(disconnecting_entity)
         {
             let username = player_identity.name.as_ref().expect("No Player Name");
@@ -130,7 +130,7 @@ pub fn connection_killer(
             leave_events.write(PlayerLeft {
                 identity: player_identity.clone(),
                 entity: disconnecting_entity,
-                game_id: *game_id
+                game_id: *game_id,
             });
         } else {
             // --- FAILURE: This is a "half-player" or zombie ---
@@ -148,7 +148,7 @@ pub fn connection_killer(
                 leave_events.write(PlayerLeft {
                     identity: player_identity.clone(),
                     entity: disconnecting_entity,
-                    game_id: *game_id
+                    game_id: *game_id,
                 });
             } else {
                 warn!("-> (Half-player didn't even have an identity component!)");

--- a/src/game_systems/src/background/src/connection_killer.rs
+++ b/src/game_systems/src/background/src/connection_killer.rs
@@ -18,6 +18,7 @@ use temper_permissions::player::PlayerPermission;
 use temper_state::GlobalStateResource;
 use temper_text::TextComponent;
 use tracing::{debug, info, trace, warn};
+use temper_components::game_id::GameID;
 
 // This type alias defines all the components of a "full" player
 type PlayerCacheQuery<'a> = (
@@ -35,14 +36,12 @@ type PlayerCacheQuery<'a> = (
     &'a EnderChest,
     &'a ActiveEffects,
     &'a PlayerPermission,
+    &'a GameID
 );
-
-// This query is a "fallback" for half-connected players
-type IdentityQuery<'a> = &'a Identity;
 
 pub fn connection_killer(
     full_player_query: Query<PlayerCacheQuery>,
-    identity_query: Query<IdentityQuery>,
+    identity_query: Query<(&Identity, &GameID)>,
     mut cmd: Commands,
     state: Res<GlobalStateResource>,
     mut leave_events: MessageWriter<PlayerLeft>,
@@ -70,6 +69,7 @@ pub fn connection_killer(
             echest,
             effects,
             permissions,
+            game_id
         )) = full_player_query.get(disconnecting_entity)
         {
             let username = player_identity.name.as_ref().expect("No Player Name");
@@ -130,6 +130,7 @@ pub fn connection_killer(
             leave_events.write(PlayerLeft {
                 identity: player_identity.clone(),
                 entity: disconnecting_entity,
+                game_id: *game_id
             });
         } else {
             // --- FAILURE: This is a "half-player" or zombie ---
@@ -139,7 +140,7 @@ pub fn connection_killer(
             );
 
             // Try to get at least the identity to broadcast the leave message
-            if let Ok(player_identity) = identity_query.get(disconnecting_entity) {
+            if let Ok((player_identity, game_id)) = identity_query.get(disconnecting_entity) {
                 warn!(
                     "-> (Half-player had identity: {})",
                     player_identity.name.as_ref().expect("No Player Name")
@@ -147,6 +148,7 @@ pub fn connection_killer(
                 leave_events.write(PlayerLeft {
                     identity: player_identity.clone(),
                     entity: disconnecting_entity,
+                    game_id: *game_id
                 });
             } else {
                 warn!("-> (Half-player didn't even have an identity component!)");

--- a/src/game_systems/src/background/src/destroy_entity.rs
+++ b/src/game_systems/src/background/src/destroy_entity.rs
@@ -2,6 +2,7 @@ use bevy_ecs::prelude::{Commands, Entity, Has, MessageReader, MessageWriter, Que
 use temper_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
 use temper_components::bossbar::BossbarOwner;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::player_marker::PlayerMarker;
 use temper_components::player::position::Position;
 use temper_core::dimension::Dimension::Overworld;
@@ -23,6 +24,7 @@ pub fn destroy_entity_system(
         Entity,
         &Position,
         &Identity,
+        &GameID,
         Has<PlayerMarker>,
         Has<MobKind>,
         Option<&StreamWriter>,
@@ -44,11 +46,19 @@ pub fn destroy_entity_system(
     };
 
     for event in destroy_entity_events.read() {
-        if let Ok((_, position, identity, has_player_marker, has_mob_kind, conn_opt, bossbar_own)) =
-            query.get(event.0)
+        if let Ok((
+            _,
+            position,
+            identity,
+            game_id,
+            has_player_marker,
+            has_mob_kind,
+            conn_opt,
+            bossbar_own,
+        )) = query.get(event.0)
         {
             if !has_player_marker {
-                destroyed_entities.push(identity.entity_id.into());
+                destroyed_entities.push(game_id.get());
                 if has_mob_kind {
                     despawn_mobs.write(DespawnMob {
                         entity: event.0,
@@ -68,7 +78,7 @@ pub fn destroy_entity_system(
                 if chunk.entities.remove(&identity.uuid).is_some() {
                     trace!(
                         "Entity {:?} destroyed and removed from chunk",
-                        identity.entity_id
+                        identity.uuid
                     );
                     chunk.mark_dirty();
                 }
@@ -84,7 +94,7 @@ pub fn destroy_entity_system(
         entity_ids: LengthPrefixedVec::new(destroyed_entities),
     };
 
-    for (_, _, _, has_player_marker, _, conn_opt, _) in query.iter() {
+    for (_, _, _, _, has_player_marker, _, conn_opt, _) in query.iter() {
         if has_player_marker
             && let Some(conn) = conn_opt
             && let Err(err) = conn.send_packet_ref(&packet)

--- a/src/game_systems/src/background/src/entity_sending.rs
+++ b/src/game_systems/src/background/src/entity_sending.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{Entity, Has, Query, Res};
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::client_information::ClientInformationComponent;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::player_marker::PlayerMarker;
@@ -11,7 +12,6 @@ use temper_protocol::outgoing::remove_entities::RemoveEntitiesPacket;
 use temper_protocol::outgoing::spawn_entity::SpawnEntityPacket;
 use temper_state::GlobalStateResource;
 use tracing::debug;
-use temper_components::game_id::GameID;
 
 /// Protocol entity type ID for player entities in the current target version.
 const PLAYER_TYPE_ID: u16 = temper_data::generated::entities::EntityType::PLAYER.id;
@@ -40,7 +40,14 @@ pub fn send_new_entities(
         &Position,
         &ClientInformationComponent,
     )>,
-    entity_query: Query<(Entity, &Identity, &GameID, &Position, &Rotation, Has<PlayerMarker>)>,
+    entity_query: Query<(
+        Entity,
+        &Identity,
+        &GameID,
+        &Position,
+        &Rotation,
+        Has<PlayerMarker>,
+    )>,
     state: Res<GlobalStateResource>,
 ) {
     for (conn, mut entity_tracker, player_pos, client_info) in player_query.iter_mut() {

--- a/src/game_systems/src/background/src/entity_sending.rs
+++ b/src/game_systems/src/background/src/entity_sending.rs
@@ -11,21 +11,22 @@ use temper_protocol::outgoing::remove_entities::RemoveEntitiesPacket;
 use temper_protocol::outgoing::spawn_entity::SpawnEntityPacket;
 use temper_state::GlobalStateResource;
 use tracing::debug;
+use temper_components::game_id::GameID;
 
 /// Protocol entity type ID for player entities in the current target version.
 const PLAYER_TYPE_ID: u16 = temper_data::generated::entities::EntityType::PLAYER.id;
 
 pub fn send_untracked_entities(
     mut player_query: Query<(&StreamWriter, &mut EntityTracker)>,
-    identity_query: Query<&Identity>,
+    identity_query: Query<&GameID>,
 ) {
     for (conn, entity_tracker) in player_query.iter_mut() {
         while let Some(entity) = entity_tracker.to_untrack.pop() {
-            let Ok(identity) = identity_query.get(entity) else {
+            let Ok(game_id) = identity_query.get(entity) else {
                 continue;
             };
 
-            let packet = RemoveEntitiesPacket::from_entities(std::iter::once(identity.clone()));
+            let packet = RemoveEntitiesPacket::from_entities(std::iter::once(*game_id));
             conn.send_packet(packet)
                 .expect("Failed to send remove entities packet");
         }
@@ -39,18 +40,18 @@ pub fn send_new_entities(
         &Position,
         &ClientInformationComponent,
     )>,
-    entity_query: Query<(Entity, &Identity, &Position, &Rotation, Has<PlayerMarker>)>,
+    entity_query: Query<(Entity, &Identity, &GameID, &Position, &Rotation, Has<PlayerMarker>)>,
     state: Res<GlobalStateResource>,
 ) {
     for (conn, mut entity_tracker, player_pos, client_info) in player_query.iter_mut() {
         let mut unresolved = Vec::new();
 
         while let Some((uuid, entity_type_id)) = entity_tracker.to_track.pop() {
-            if let Some((entity, identity, entity_pos, rot, is_player)) = entity_query
+            if let Some((entity, identity, game_id, entity_pos, rot, is_player)) = entity_query
                 .iter()
-                .find_map(|(entity, identity, pos, rot, is_player)| {
+                .find_map(|(entity, identity, game_id, pos, rot, is_player)| {
                     if identity.uuid == uuid {
-                        Some((entity, identity, pos, rot, is_player))
+                        Some((entity, identity, game_id, pos, rot, is_player))
                     } else {
                         None
                     }
@@ -74,7 +75,7 @@ pub fn send_new_entities(
                 };
 
                 let packet = SpawnEntityPacket::new(
-                    identity.entity_id,
+                    game_id.get(),
                     identity.uuid.as_u128(),
                     i32::from(entity_type_id),
                     entity_pos,
@@ -84,8 +85,8 @@ pub fn send_new_entities(
                 conn.send_packet(packet)
                     .expect("Failed to send spawn entity packet");
                 debug!(
-                    "Sent spawn packet for entity {} with UUID {} to player at position {:?}",
-                    identity.entity_id,
+                    "Sent spawn packet for entity {:#x} with UUID {} to player at position {:?}",
+                    game_id.get().0,
                     identity.uuid,
                     player_pos.xyz()
                 );

--- a/src/game_systems/src/background/src/entity_sending.rs
+++ b/src/game_systems/src/background/src/entity_sending.rs
@@ -85,10 +85,12 @@ pub fn send_new_entities(
                 conn.send_packet(packet)
                     .expect("Failed to send spawn entity packet");
                 debug!(
-                    "Sent spawn packet for entity {:#x} with UUID {} to player at position {:?}",
+                    "Sent spawn packet for entity {:#x} with UUID {} to player at position ({:.2} {:.2} {:.2})",
                     game_id.get().0,
                     identity.uuid,
-                    player_pos.xyz()
+                    player_pos.x,
+                    player_pos.y,
+                    player_pos.z,
                 );
                 entity_tracker.tracking.insert(entity);
             } else {

--- a/src/game_systems/src/background/src/entity_tracking.rs
+++ b/src/game_systems/src/background/src/entity_tracking.rs
@@ -6,12 +6,14 @@ use temper_components::player::player_marker::PlayerMarker;
 use temper_components::player::position::Position;
 use temper_net_runtime::connection::StreamWriter;
 use tracing::trace;
+use temper_components::game_id::GameID;
 
 pub fn refresh_visible_entities(
     mut player_query: Query<(Entity, &StreamWriter, &ChunkReceiver, &mut EntityTracker)>,
     entity_query: Query<(
         Entity,
         &Identity,
+        &GameID,
         &Position,
         Has<PlayerMarker>,
         Option<&StreamWriter>,
@@ -26,7 +28,7 @@ pub fn refresh_visible_entities(
         for tracked_entity in tracked_entities {
             let should_keep = entity_query
                 .get(tracked_entity)
-                .map(|(entity, _identity, pos, is_player, maybe_writer)| {
+                .map(|(entity, _identity, _game_id, pos, is_player, maybe_writer)| {
                     if entity == player_entity {
                         return false;
                     }
@@ -45,7 +47,7 @@ pub fn refresh_visible_entities(
             }
         }
 
-        for (entity, identity, pos, is_player, maybe_writer) in entity_query.iter() {
+        for (entity, identity, game_id, pos, is_player, maybe_writer) in entity_query.iter() {
             if entity == player_entity {
                 continue;
             }
@@ -63,8 +65,8 @@ pub fn refresh_visible_entities(
             }
 
             trace!(
-                "Queueing entity {} ({:?}) for player {:?}",
-                identity.entity_id, identity.uuid, player_entity
+                "Queueing entity {:#x} ({:?}) for player {:?}",
+                game_id.get().0, identity.uuid, player_entity
             );
             tracker.to_track.push((identity.uuid, 0));
         }

--- a/src/game_systems/src/background/src/entity_tracking.rs
+++ b/src/game_systems/src/background/src/entity_tracking.rs
@@ -1,12 +1,12 @@
 use bevy_ecs::prelude::{Entity, Has, Query};
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::chunk_receiver::ChunkReceiver;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::player_marker::PlayerMarker;
 use temper_components::player::position::Position;
 use temper_net_runtime::connection::StreamWriter;
 use tracing::trace;
-use temper_components::game_id::GameID;
 
 pub fn refresh_visible_entities(
     mut player_query: Query<(Entity, &StreamWriter, &ChunkReceiver, &mut EntityTracker)>,
@@ -28,17 +28,19 @@ pub fn refresh_visible_entities(
         for tracked_entity in tracked_entities {
             let should_keep = entity_query
                 .get(tracked_entity)
-                .map(|(entity, _identity, _game_id, pos, is_player, maybe_writer)| {
-                    if entity == player_entity {
-                        return false;
-                    }
+                .map(
+                    |(entity, _identity, _game_id, pos, is_player, maybe_writer)| {
+                        if entity == player_entity {
+                            return false;
+                        }
 
-                    if is_player && maybe_writer.is_none_or(|writer| !writer.is_running()) {
-                        return false;
-                    }
+                        if is_player && maybe_writer.is_none_or(|writer| !writer.is_running()) {
+                            return false;
+                        }
 
-                    chunk_receiver.loaded.contains(&pos.chunk())
-                })
+                        chunk_receiver.loaded.contains(&pos.chunk())
+                    },
+                )
                 .unwrap_or(false);
 
             if !should_keep {
@@ -66,7 +68,9 @@ pub fn refresh_visible_entities(
 
             trace!(
                 "Queueing entity {:#x} ({:?}) for player {:?}",
-                game_id.get().0, identity.uuid, player_entity
+                game_id.get().0,
+                identity.uuid,
+                player_entity
             );
             tracker.to_track.push((identity.uuid, 0));
         }

--- a/src/game_systems/src/background/src/generate_spawn_positions.rs
+++ b/src/game_systems/src/background/src/generate_spawn_positions.rs
@@ -9,7 +9,7 @@ use temper_core::pos::{ChunkBlockPos, ChunkPos};
 use temper_macros::match_block;
 use temper_state::GlobalStateResource;
 use temper_world::RefChunk;
-use tracing::{error, info};
+use tracing::{error, info, trace};
 
 const SPAWN_CENTER: (i32, i32) = (8, 8);
 const SPAWN_SEARCH_BUDGET: Duration = Duration::from_millis(30);
@@ -39,7 +39,7 @@ pub fn generate_spawn_positions(state: Res<GlobalStateResource>) {
 
         for (chunk_x, chunk_z) in chunks {
             if state.0.spawn_positions.is_full() {
-                info!(
+                trace!(
                     "Finished generating {} spawn positions in {:.2} ms",
                     found_coords,
                     start.elapsed().as_secs_f32() * 1000.0

--- a/src/game_systems/src/background/src/send_entity_updates.rs
+++ b/src/game_systems/src/background/src/send_entity_updates.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{Entity, MessageReader, Query};
 use temper_codec::net_types::angle::NetAngle;
+use temper_components::game_id::GameID;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::grounded::OnGround;
 use temper_components::player::position::Position;
@@ -11,7 +12,6 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_position_sync::TeleportEntityPacket;
 use temper_protocol::outgoing::update_entity_position_and_rotation::UpdateEntityPositionAndRotationPacket;
 use tracing::warn;
-use temper_components::game_id::GameID;
 
 pub fn handle(
     mut query: Query<(

--- a/src/game_systems/src/background/src/send_entity_updates.rs
+++ b/src/game_systems/src/background/src/send_entity_updates.rs
@@ -1,6 +1,5 @@
 use bevy_ecs::prelude::{Entity, MessageReader, Query};
 use temper_codec::net_types::angle::NetAngle;
-use temper_components::entity_identity::Identity;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::grounded::OnGround;
 use temper_components::player::position::Position;
@@ -12,6 +11,7 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_position_sync::TeleportEntityPacket;
 use temper_protocol::outgoing::update_entity_position_and_rotation::UpdateEntityPositionAndRotationPacket;
 use tracing::warn;
+use temper_components::game_id::GameID;
 
 pub fn handle(
     mut query: Query<(
@@ -20,7 +20,7 @@ pub fn handle(
         &Velocity,
         &Rotation,
         &mut LastSyncedPosition,
-        &Identity,
+        &GameID,
         &OnGround,
     )>,
     mut player_query: Query<(Entity, &StreamWriter, &EntityTracker)>,
@@ -31,12 +31,12 @@ pub fn handle(
         entities_to_update.push(msg.0);
     }
     for entity in entities_to_update {
-        if let Ok((entity, pos, vel, rot, mut last_synced, identity, grounded)) =
+        if let Ok((entity, pos, vel, rot, mut last_synced, game_id, grounded)) =
             query.get_mut(entity)
         {
             if last_synced.0.distance(pos.coords) >= 8.0 {
                 let packet = TeleportEntityPacket {
-                    entity_id: identity.entity_id.into(),
+                    entity_id: game_id.get(),
                     x: pos.x,
                     y: pos.y,
                     z: pos.z,
@@ -68,7 +68,7 @@ pub fn handle(
                     )
                 };
                 let packet = UpdateEntityPositionAndRotationPacket {
-                    entity_id: identity.entity_id.into(),
+                    entity_id: game_id.get(),
                     delta_x,
                     delta_y,
                     delta_z,

--- a/src/game_systems/src/background/tests/entity_tracking.rs
+++ b/src/game_systems/src/background/tests/entity_tracking.rs
@@ -3,6 +3,7 @@ use bevy_ecs::prelude::{Schedule, World};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::chunk_receiver::ChunkReceiver;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::player_marker::PlayerMarker;
@@ -52,7 +53,9 @@ async fn visible_mobs_without_stream_writers_stay_tracked() {
 
     let mut world = World::new();
     let mob_position = Position::new(8.0, 64.0, 8.0);
-    let mob_entity = world.spawn((Identity::new(None), mob_position)).id();
+    let mob_entity = world
+        .spawn((Identity::new(None), GameID::new(), mob_position))
+        .id();
 
     let mut chunk_receiver = ChunkReceiver::default();
     chunk_receiver.loaded.insert(mob_position.chunk());

--- a/src/game_systems/src/packets/src/player_command.rs
+++ b/src/game_systems/src/packets/src/player_command.rs
@@ -1,13 +1,12 @@
 use bevy_ecs::prelude::{Entity, Query, Res};
-use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::PlayerCommandPacketReceiver;
 use temper_protocol::incoming::player_command::PlayerCommandAction;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use tracing::trace;
-use temper_components::game_id::GameID;
 
 /// Handles PlayerCommand packets (sprinting, leave bed, etc.)
 /// Note: Sneaking is handled via PlayerInput packet, NOT here

--- a/src/game_systems/src/packets/src/player_command.rs
+++ b/src/game_systems/src/packets/src/player_command.rs
@@ -7,27 +7,28 @@ use temper_protocol::PlayerCommandPacketReceiver;
 use temper_protocol::incoming::player_command::PlayerCommandAction;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use tracing::trace;
+use temper_components::game_id::GameID;
 
 /// Handles PlayerCommand packets (sprinting, leave bed, etc.)
 /// Note: Sneaking is handled via PlayerInput packet, NOT here
 pub fn handle(
     receiver: Res<PlayerCommandPacketReceiver>,
     conn_query: Query<(Entity, &StreamWriter, &EntityTracker)>,
-    identity_query: Query<&Identity>,
+    identity_query: Query<(&Identity, &GameID)>,
 ) {
     for (event, eid) in receiver.0.try_iter() {
         // Get the sender's identity to use the correct entity ID
-        let Ok(identity) = identity_query.get(eid) else {
+        let Ok((identity, game_id)) = identity_query.get(eid) else {
             continue;
         };
 
-        let entity_id = VarInt::new(identity.entity_id);
+        let entity_id = game_id.get();
 
         trace!(
             "PlayerCommand: {:?} from {} (entity_id={})",
             event.action,
             identity.name.as_ref().expect("No Player Name"),
-            identity.entity_id
+            game_id.get()
         );
 
         match event.action {

--- a/src/game_systems/src/packets/src/player_input.rs
+++ b/src/game_systems/src/packets/src/player_input.rs
@@ -4,15 +4,14 @@
 //! NOT via PlayerCommand (which was used in older protocol versions).
 
 use bevy_ecs::prelude::{Entity, Query, Res};
-use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::sneak::SneakState;
 use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::PlayerInputReceiver;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use tracing::{debug, warn};
-use temper_components::game_id::GameID;
 
 /// PlayerInput flags (1.21.x protocol)
 const FLAG_SNEAK: u8 = 0x20;

--- a/src/game_systems/src/packets/src/player_input.rs
+++ b/src/game_systems/src/packets/src/player_input.rs
@@ -12,6 +12,7 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::PlayerInputReceiver;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use tracing::{debug, warn};
+use temper_components::game_id::GameID;
 
 /// PlayerInput flags (1.21.x protocol)
 const FLAG_SNEAK: u8 = 0x20;
@@ -21,11 +22,11 @@ const FLAG_SNEAK: u8 = 0x20;
 pub fn handle(
     receiver: Res<PlayerInputReceiver>,
     conn_query: Query<(Entity, &StreamWriter, &EntityTracker)>,
-    identity_query: Query<&Identity>,
+    identity_query: Query<(&Identity, &GameID)>,
     mut sneak_query: Query<&mut SneakState>,
 ) {
     for (event, eid) in receiver.0.try_iter() {
-        let Ok(identity) = identity_query.get(eid) else {
+        let Ok((identity, game_id)) = identity_query.get(eid) else {
             continue;
         };
 
@@ -46,18 +47,17 @@ pub fn handle(
         }
 
         sneak_state.is_sneaking = is_sneaking;
-        let entity_id = VarInt::new(identity.entity_id);
 
         debug!(
             "PlayerInput: sneak={} from {} (entity_id={})",
             is_sneaking,
             identity.name.as_ref().expect("No Player Name"),
-            identity.entity_id
+            game_id.get()
         );
 
         let packet = if is_sneaking {
             EntityMetadataPacket::new(
-                entity_id,
+                game_id.get(),
                 [
                     EntityMetadata::entity_sneaking_flag(),
                     EntityMetadata::entity_sneaking_visual(),
@@ -65,7 +65,7 @@ pub fn handle(
             )
         } else {
             EntityMetadataPacket::new(
-                entity_id,
+                game_id.get(),
                 [
                     EntityMetadata::entity_clear_state(),
                     EntityMetadata::entity_standing(),

--- a/src/game_systems/src/packets/src/player_loaded.rs
+++ b/src/game_systems/src/packets/src/player_loaded.rs
@@ -23,7 +23,7 @@ pub fn handle(
             continue;
         }
         tracing::info!(
-            "Player {} loaded at position: ({}, {}, {})",
+            "Player {} loaded at position: ({:.2}, {:.2}, {:.2})",
             identity.name.as_ref().expect("No Player Name"),
             player_pos.x,
             player_pos.y,

--- a/src/game_systems/src/packets/src/set_player_position.rs
+++ b/src/game_systems/src/packets/src/set_player_position.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{Entity, MessageWriter, Query, Res};
 
+use temper_components::entity_identity::Identity;
 use temper_components::player::grounded::OnGround;
 use temper_components::player::position::Position;
 use temper_components::player::teleport_tracker::TeleportTracker;
@@ -7,11 +8,16 @@ use temper_messages::cross_chunk_boundary_event::ChunkBoundaryCrossed;
 use temper_messages::packet_messages::Movement;
 use temper_protocol::SetPlayerPositionPacketReceiver;
 use tracing::trace;
-use temper_components::entity_identity::Identity;
 
 pub fn handle(
     receiver: Res<SetPlayerPositionPacketReceiver>,
-    mut query: Query<(Entity, &mut Position, &mut OnGround, &TeleportTracker, &Identity)>,
+    mut query: Query<(
+        Entity,
+        &mut Position,
+        &mut OnGround,
+        &TeleportTracker,
+        &Identity,
+    )>,
     mut movement_messages: MessageWriter<Movement>,
     mut cross_chunk_border_msg: MessageWriter<ChunkBoundaryCrossed>,
 ) {
@@ -50,7 +56,10 @@ pub fn handle(
 
             trace!(
                 "Updated position for player {}: ({:.2}, {:.2}, {:.2})",
-                identity.name.as_ref().unwrap(), event.x, event.feet_y, event.z
+                identity.name.as_ref().unwrap(),
+                event.x,
+                event.feet_y,
+                event.z
             );
         }
     }

--- a/src/game_systems/src/packets/src/set_player_position.rs
+++ b/src/game_systems/src/packets/src/set_player_position.rs
@@ -7,15 +7,16 @@ use temper_messages::cross_chunk_boundary_event::ChunkBoundaryCrossed;
 use temper_messages::packet_messages::Movement;
 use temper_protocol::SetPlayerPositionPacketReceiver;
 use tracing::trace;
+use temper_components::entity_identity::Identity;
 
 pub fn handle(
     receiver: Res<SetPlayerPositionPacketReceiver>,
-    mut query: Query<(Entity, &mut Position, &mut OnGround, &TeleportTracker)>,
+    mut query: Query<(Entity, &mut Position, &mut OnGround, &TeleportTracker, &Identity)>,
     mut movement_messages: MessageWriter<Movement>,
     mut cross_chunk_border_msg: MessageWriter<ChunkBoundaryCrossed>,
 ) {
     for (event, eid) in receiver.0.try_iter() {
-        if let Ok((entity, mut old_pos, mut ground, tracker)) = query.get_mut(eid) {
+        if let Ok((entity, mut old_pos, mut ground, tracker, identity)) = query.get_mut(eid) {
             if tracker.waiting_for_confirm {
                 // Ignore position updates while waiting for teleport confirmation
                 continue;
@@ -48,8 +49,8 @@ pub fn handle(
             movement_messages.write(movement);
 
             trace!(
-                "Updated position for player {}: ({}, {}, {})",
-                eid, event.x, event.feet_y, event.z
+                "Updated position for player {}: ({:.2}, {:.2}, {:.2})",
+                identity.name.as_ref().unwrap(), event.x, event.feet_y, event.z
             );
         }
     }

--- a/src/game_systems/src/packets/src/swing_arm.rs
+++ b/src/game_systems/src/packets/src/swing_arm.rs
@@ -7,10 +7,11 @@ use temper_protocol::SwingArmPacketReceiver;
 use temper_protocol::outgoing::entity_animation::EntityAnimationPacket;
 use temper_state::GlobalStateResource;
 use tracing::error;
+use temper_components::game_id::GameID;
 
 pub fn handle(
     receiver: Res<SwingArmPacketReceiver>,
-    query: Query<&Identity>,
+    query: Query<&GameID>,
     conn_query: Query<(Entity, &StreamWriter, &EntityTracker)>,
     state: Res<GlobalStateResource>,
 ) {
@@ -20,7 +21,7 @@ pub fn handle(
             error!("Game ID not found for entity: {:?}", eid);
             continue;
         };
-        let packet = EntityAnimationPacket::new(VarInt::new(game_id.entity_id), animation);
+        let packet = EntityAnimationPacket::new(game_id.get(), animation);
         for (entity, conn, tracker) in conn_query.iter() {
             if entity == eid {
                 continue; // Skip sending to the player who triggered the event

--- a/src/game_systems/src/packets/src/swing_arm.rs
+++ b/src/game_systems/src/packets/src/swing_arm.rs
@@ -1,13 +1,11 @@
 use bevy_ecs::prelude::{Entity, Query, Res};
-use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::SwingArmPacketReceiver;
 use temper_protocol::outgoing::entity_animation::EntityAnimationPacket;
 use temper_state::GlobalStateResource;
 use tracing::error;
-use temper_components::game_id::GameID;
 
 pub fn handle(
     receiver: Res<SwingArmPacketReceiver>,

--- a/src/game_systems/src/player/src/movement_broadcast.rs
+++ b/src/game_systems/src/player/src/movement_broadcast.rs
@@ -28,6 +28,7 @@ use temper_protocol::outgoing::update_entity_rotation::UpdateEntityRotationPacke
 
 use temper_messages::packet_messages::Movement;
 use tracing::error;
+use temper_components::game_id::GameID;
 
 /// Enum to hold all possible movement broadcast packets.
 /// Using an enum with `#[derive(NetEncode)]` allows sending any variant
@@ -53,13 +54,13 @@ const MAX_DELTA: i16 = (7.5 * 4096f32) as i16;
 /// broadcast logic, ensuring consistent handling across all movement packet types.
 pub fn handle_player_move(
     mut movement_msgs: MessageReader<Movement>,
-    query: Query<(&Position, &Rotation, &Identity)>,
+    query: Query<(&Position, &Rotation, &GameID)>,
     broadcast_query: Query<(Entity, &StreamWriter, &EntityTracker)>,
 ) {
     for movement in movement_msgs.read() {
         let sender_entity = movement.entity;
 
-        let Ok((pos, rot, identity)) = query.get(sender_entity) else {
+        let Ok((pos, rot, game_id)) = query.get(sender_entity) else {
             continue;
         };
 
@@ -92,14 +93,14 @@ pub fn handle_player_move(
         // Build the appropriate movement packet
         let movement_packet: Option<BroadcastMovementPacket> = if delta_exceeds_threshold {
             Some(BroadcastMovementPacket::TeleportEntity(
-                TeleportEntityPacket::new(identity, pos, rot, movement.on_ground),
+                TeleportEntityPacket::new(game_id, pos, rot, movement.on_ground),
             ))
         } else {
             match (movement.delta_position, has_rotation) {
                 (Some(delta), true) => {
                     Some(BroadcastMovementPacket::UpdateEntityPositionAndRotation(
                         UpdateEntityPositionAndRotationPacket::new(
-                            identity,
+                            game_id,
                             delta,
                             rot,
                             movement.on_ground,
@@ -107,10 +108,10 @@ pub fn handle_player_move(
                     ))
                 }
                 (Some(delta), false) => Some(BroadcastMovementPacket::UpdateEntityPosition(
-                    UpdateEntityPositionPacket::new(identity, delta, movement.on_ground),
+                    UpdateEntityPositionPacket::new(game_id, delta, movement.on_ground),
                 )),
                 (None, true) => Some(BroadcastMovementPacket::UpdateEntityRotation(
-                    UpdateEntityRotationPacket::new(identity, rot, movement.on_ground),
+                    UpdateEntityRotationPacket::new(game_id, rot, movement.on_ground),
                 )),
                 (None, false) => None,
             }
@@ -119,7 +120,7 @@ pub fn handle_player_move(
         // Build head rotation packet if we have rotation
         let head_rot_packet = if has_rotation {
             Some(SetHeadRotationPacket::new(
-                identity.entity_id,
+                game_id.get(),
                 NetAngle::from_degrees(f64::from(rot.yaw)),
             ))
         } else {

--- a/src/game_systems/src/player/src/movement_broadcast.rs
+++ b/src/game_systems/src/player/src/movement_broadcast.rs
@@ -14,7 +14,6 @@
 
 use bevy_ecs::prelude::{Entity, MessageReader, Query};
 use temper_codec::net_types::angle::NetAngle;
-use temper_components::entity_identity::Identity;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::position::Position;
 use temper_components::player::rotation::Rotation;
@@ -26,9 +25,9 @@ use temper_protocol::outgoing::update_entity_position::UpdateEntityPositionPacke
 use temper_protocol::outgoing::update_entity_position_and_rotation::UpdateEntityPositionAndRotationPacket;
 use temper_protocol::outgoing::update_entity_rotation::UpdateEntityRotationPacket;
 
+use temper_components::game_id::GameID;
 use temper_messages::packet_messages::Movement;
 use tracing::error;
-use temper_components::game_id::GameID;
 
 /// Enum to hold all possible movement broadcast packets.
 /// Using an enum with `#[derive(NetEncode)]` allows sending any variant

--- a/src/game_systems/src/player/src/new_connections.rs
+++ b/src/game_systems/src/player/src/new_connections.rs
@@ -60,6 +60,7 @@ pub fn accept_new_connections(
         // --- 2. Build the PlayerBundle ---
         let player_bundle = PlayerBundle {
             identity: new_connection.player_identity.clone(),
+            game_id: new_connection.game_id,
             abilities: player_data.abilities,
             player_properties: new_connection.player_properties,
             gamemode: GameModeComponent(player_data.gamemode),

--- a/src/game_systems/src/player/src/player_despawn.rs
+++ b/src/game_systems/src/player/src/player_despawn.rs
@@ -22,11 +22,12 @@ pub fn handle(
 ) {
     for event in events.read() {
         let left_player = &event.identity;
+        let game_id = event.game_id;
 
         // Create packets once
         let remove_info_packet = PlayerInfoRemovePacket::single(left_player.uuid.as_u128());
         let remove_entity_packet =
-            RemoveEntitiesPacket::from_entities(std::iter::once(left_player.clone()));
+            RemoveEntitiesPacket::from_entities(std::iter::once(game_id));
 
         let mut notified_count = 0;
 

--- a/src/game_systems/src/player/src/player_despawn.rs
+++ b/src/game_systems/src/player/src/player_despawn.rs
@@ -26,8 +26,7 @@ pub fn handle(
 
         // Create packets once
         let remove_info_packet = PlayerInfoRemovePacket::single(left_player.uuid.as_u128());
-        let remove_entity_packet =
-            RemoveEntitiesPacket::from_entities(std::iter::once(game_id));
+        let remove_entity_packet = RemoveEntitiesPacket::from_entities(std::iter::once(game_id));
 
         let mut notified_count = 0;
 

--- a/src/game_systems/src/player/src/player_swimming.rs
+++ b/src/game_systems/src/player/src/player_swimming.rs
@@ -1,8 +1,7 @@
 use bevy_ecs::prelude::*;
 use bevy_math::DVec3;
 use std::collections::HashSet;
-use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::entity_tracker::EntityTracker;
 use temper_components::player::position::Position;
 use temper_components::player::swimming::SwimmingState;
@@ -15,7 +14,6 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use temper_state::GlobalStateResource;
 use tracing::error;
-use temper_components::game_id::GameID;
 
 /// Height of player's eyes from feet (blocks)
 const PLAYER_EYE_HEIGHT: f64 = 1.62;

--- a/src/game_systems/src/player/src/player_swimming.rs
+++ b/src/game_systems/src/player/src/player_swimming.rs
@@ -15,6 +15,7 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_metadata::{EntityMetadata, EntityMetadataPacket};
 use temper_state::GlobalStateResource;
 use tracing::error;
+use temper_components::game_id::GameID;
 
 /// Height of player's eyes from feet (blocks)
 const PLAYER_EYE_HEIGHT: f64 = 1.62;
@@ -44,7 +45,7 @@ fn is_player_in_water(state: &temper_state::GlobalState, pos: &Position) -> bool
 /// System that detects when players enter/exit water and updates their swimming state
 /// Also broadcasts the swimming pose to all connected clients
 pub fn detect_player_swimming(
-    mut swimmers: Query<(Entity, &Identity, Ref<Position>, &mut SwimmingState)>,
+    mut swimmers: Query<(Entity, &GameID, Ref<Position>, &mut SwimmingState)>,
     all_connections: Query<(Entity, &StreamWriter, &EntityTracker)>,
     state: Res<GlobalStateResource>,
     mut world_change: MessageReader<WorldChange>,
@@ -55,7 +56,7 @@ pub fn detect_player_swimming(
             changed_chunks.insert(pos);
         }
     }
-    for (entity, identity, pos, mut swimming_state) in swimmers.iter_mut() {
+    for (entity, game_id, pos, mut swimming_state) in swimmers.iter_mut() {
         if !changed_chunks.contains(&pos.chunk()) && !pos.is_changed() {
             continue;
         }
@@ -64,9 +65,8 @@ pub fn detect_player_swimming(
         if in_water && !swimming_state.is_swimming {
             swimming_state.is_swimming = true;
 
-            let entity_id = VarInt::new(identity.entity_id);
             let packet = EntityMetadataPacket::new(
-                entity_id,
+                game_id.get(),
                 [
                     EntityMetadata::entity_swimming_state(),
                     EntityMetadata::entity_swimming_pose(),
@@ -77,9 +77,8 @@ pub fn detect_player_swimming(
         } else if !in_water && swimming_state.is_swimming {
             swimming_state.is_swimming = false;
 
-            let entity_id = VarInt::new(identity.entity_id);
             let packet = EntityMetadataPacket::new(
-                entity_id,
+                game_id.get(),
                 [
                     EntityMetadata::entity_clear_state(),
                     EntityMetadata::entity_standing(),

--- a/src/game_systems/src/player/src/teleport.rs
+++ b/src/game_systems/src/player/src/teleport.rs
@@ -11,6 +11,7 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_position_sync::TeleportEntityPacket;
 use temper_protocol::outgoing::synchronize_player_position::SynchronizePlayerPositionPacket;
 use tracing::error;
+use temper_components::game_id::GameID;
 
 pub fn teleport_entities(
     mut target_query: Query<(
@@ -21,7 +22,7 @@ pub fn teleport_entities(
         Option<&mut TeleportTracker>,
     )>,
     player_query: Query<(Entity, &StreamWriter)>,
-    id_query: Query<&Identity>,
+    id_query: Query<&GameID>,
     mut message_reader: MessageReader<TeleportEntity>,
     mut chunk_calc_msg: MessageWriter<ChunkCalc>,
     mut player_update_msg: MessageWriter<SendEntityUpdate>,
@@ -96,7 +97,7 @@ pub fn teleport_entities(
             // This ideally should be handled by the send entity updates system, but it seems to be
             // a bit buggy.
             if let Err(err) = conn.send_packet(TeleportEntityPacket {
-                entity_id: id.entity_id.into(),
+                entity_id: id.get(),
                 x: message.position.x,
                 y: message.position.y,
                 z: message.position.z,

--- a/src/game_systems/src/player/src/teleport.rs
+++ b/src/game_systems/src/player/src/teleport.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::{Entity, MessageReader, MessageWriter, Query};
-use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::position::Position;
 use temper_components::player::rotation::Rotation;
 use temper_components::player::teleport_tracker::TeleportTracker;
@@ -11,7 +11,6 @@ use temper_net_runtime::connection::StreamWriter;
 use temper_protocol::outgoing::entity_position_sync::TeleportEntityPacket;
 use temper_protocol::outgoing::synchronize_player_position::SynchronizePlayerPositionPacket;
 use tracing::error;
-use temper_components::game_id::GameID;
 
 pub fn teleport_entities(
     mut target_query: Query<(
@@ -152,6 +151,7 @@ mod tests {
         let entity = world
             .spawn((
                 Identity::default(),
+                GameID::new(),
                 Position::new(0.0, 64.0, 0.0),
                 Rotation::default(),
                 Velocity::new(1.0, 0.0, 0.0),

--- a/src/game_systems/tests/mobs/entity_persistence.rs
+++ b/src/game_systems/tests/mobs/entity_persistence.rs
@@ -245,10 +245,50 @@ fn pig_round_trips_through_chunk_save_and_load() {
     assert!(has_collisions, "loaded pig should regain HasCollisions");
     assert!(has_water_drag, "loaded pig should regain HasWaterDrag");
     assert_eq!(identity.uuid, expected_identity.uuid);
-    assert_eq!(identity.entity_id, expected_identity.entity_id);
     assert_eq!(loaded_position.coords, position.coords);
     assert_eq!(last_chunk.0, chunk);
     assert_eq!(last_synced.0, expected_last_synced.0);
+}
+
+#[test]
+fn chunk_storage_does_not_persist_game_id() {
+    let mut world = World::new();
+    temper_messages::register_messages(&mut world);
+
+    let (state, _temp_dir) = create_test_state();
+    world.insert_resource(state);
+
+    let position = Position::new(5.5, 64.0, 7.5);
+    let chunk = position.chunk();
+    let bundle = PigBundle::new(position);
+    let expected_identity = bundle.identity.clone();
+    let original_game_id = bundle.game_id;
+
+    spawn_pig(&mut world, bundle);
+
+    let mut save_schedule = Schedule::default();
+    save_schedule.add_systems((emit_save_for(chunk), save_mob_bundles).chain());
+    save_schedule.run(&mut world);
+
+    let state = world.resource::<temper_state::GlobalStateResource>();
+    let saved_chunk = state
+        .0
+        .world
+        .get_chunk(chunk, Dimension::Overworld)
+        .expect("chunk should exist after save");
+    let saved_entity = saved_chunk
+        .entities
+        .get(&expected_identity.uuid)
+        .expect("saved pig should be present in chunk storage");
+    let saved_bundle = MobBundle::deserialize(saved_entity.value().0, &saved_entity.value().1)
+        .expect("saved pig bundle should deserialize");
+
+    let MobBundle::Pig(saved_pig) = saved_bundle else {
+        panic!("saved entity should deserialize as a pig");
+    };
+
+    assert_eq!(saved_pig.identity.uuid, expected_identity.uuid);
+    assert_ne!(saved_pig.game_id, original_game_id);
 }
 
 #[test]
@@ -823,7 +863,6 @@ fn fox_loads_in_a_separate_ecs_world_after_save() {
     assert!(has_collisions, "loaded fox should regain HasCollisions");
     assert!(has_water_drag, "loaded fox should regain HasWaterDrag");
     assert_eq!(identity.uuid, expected_identity.uuid);
-    assert_eq!(identity.entity_id, expected_identity.entity_id);
     assert_eq!(loaded_position.coords, position.coords);
     assert_eq!(last_chunk.0, chunk);
     assert_eq!(last_synced.0, expected_last_synced.0);

--- a/src/game_systems/tests/mobs/player_distance_reload.rs
+++ b/src/game_systems/tests/mobs/player_distance_reload.rs
@@ -204,7 +204,6 @@ fn player_can_unload_entities_by_moving_away_and_reload_them_after_returning() {
     assert!(has_collisions, "reloaded fox should regain HasCollisions");
     assert!(has_water_drag, "reloaded fox should regain HasWaterDrag");
     assert_eq!(identity.uuid, expected_identity.uuid);
-    assert_eq!(identity.entity_id, expected_identity.entity_id);
     assert_eq!(loaded_position.coords, fox_position.coords);
     assert_eq!(last_chunk.0, fox_chunk);
     assert_eq!(last_synced.0, expected_last_synced.0);

--- a/src/messages/src/player_leave.rs
+++ b/src/messages/src/player_leave.rs
@@ -1,9 +1,11 @@
 use bevy_ecs::prelude::*;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 
 #[derive(Message, Clone)]
 #[allow(unused)]
 pub struct PlayerLeft {
     pub identity: Identity,
     pub entity: Entity,
+    pub game_id: GameID
 }

--- a/src/messages/src/player_leave.rs
+++ b/src/messages/src/player_leave.rs
@@ -7,5 +7,5 @@ use temper_components::game_id::GameID;
 pub struct PlayerLeft {
     pub identity: Identity,
     pub entity: Entity,
-    pub game_id: GameID
+    pub game_id: GameID,
 }

--- a/src/net/codec/src/net_types/network_position.rs
+++ b/src/net/codec/src/net_types/network_position.rs
@@ -20,7 +20,7 @@ pub struct NetworkPosition {
 
 impl Display for NetworkPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}, {}, {})", self.x, self.y, self.z)
+        write!(f, "({:.2}, {:.2}, {:.2})", self.x, self.y, self.z)
     }
 }
 

--- a/src/net/protocol/build.rs
+++ b/src/net/protocol/build.rs
@@ -315,13 +315,14 @@ use bevy_ecs::world::World;
 pub fn handle_packet<R: std::io::Read>(
     packet_id: u8,
     entity: bevy_ecs::entity::Entity,
+    player_name: String,
     cursor: &mut R,
     packet_sender: Arc<PacketSender>,
 ) -> Result<(), crate::errors::NetError> {{
     match packet_id {{
 {match_arms}
         _ => {{
-            tracing::debug!("No packet found for ID: 0x{{:02X}} (from {{}})", packet_id, entity);
+            tracing::debug!("No packet found for ID: 0x{{:02X}} (from {{}})", packet_id, player_name);
             Err(crate::errors::PacketError::InvalidPacket(packet_id).into())
         }}
     }}

--- a/src/net/protocol/build.rs
+++ b/src/net/protocol/build.rs
@@ -315,7 +315,7 @@ use bevy_ecs::world::World;
 pub fn handle_packet<R: std::io::Read>(
     packet_id: u8,
     entity: bevy_ecs::entity::Entity,
-    player_name: String,
+    player_name: &str,
     cursor: &mut R,
     packet_sender: Arc<PacketSender>,
 ) -> Result<(), crate::errors::NetError> {{

--- a/src/net/protocol/src/outgoing/entity_position_sync.rs
+++ b/src/net/protocol/src/outgoing/entity_position_sync.rs
@@ -20,12 +20,7 @@ pub struct TeleportEntityPacket {
 }
 
 impl TeleportEntityPacket {
-    pub fn new(
-        entity_id: &GameID,
-        position: &Position,
-        angle: &Rotation,
-        on_ground: bool,
-    ) -> Self {
+    pub fn new(entity_id: &GameID, position: &Position, angle: &Rotation, on_ground: bool) -> Self {
         // Todo: Add velocity parameters if needed
         Self {
             entity_id: entity_id.get(),

--- a/src/net/protocol/src/outgoing/entity_position_sync.rs
+++ b/src/net/protocol/src/outgoing/entity_position_sync.rs
@@ -1,5 +1,5 @@
 use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::position::Position;
 use temper_components::player::rotation::Rotation;
 use temper_macros::{NetEncode, packet};
@@ -21,14 +21,14 @@ pub struct TeleportEntityPacket {
 
 impl TeleportEntityPacket {
     pub fn new(
-        entity_id: &Identity,
+        entity_id: &GameID,
         position: &Position,
         angle: &Rotation,
         on_ground: bool,
     ) -> Self {
         // Todo: Add velocity parameters if needed
         Self {
-            entity_id: VarInt::new(entity_id.entity_id),
+            entity_id: entity_id.get(),
             x: position.x,
             y: position.y,
             z: position.z,

--- a/src/net/protocol/src/outgoing/remove_entities.rs
+++ b/src/net/protocol/src/outgoing/remove_entities.rs
@@ -1,6 +1,5 @@
 use temper_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
 use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
 use temper_components::game_id::GameID;
 use temper_macros::{NetEncode, packet};
 
@@ -15,10 +14,7 @@ impl RemoveEntitiesPacket {
     where
         T: IntoIterator<Item = GameID>,
     {
-        let entity_ids: Vec<VarInt> = entity_ids
-            .into_iter()
-            .map(|entity| entity.get())
-            .collect();
+        let entity_ids: Vec<VarInt> = entity_ids.into_iter().map(|entity| entity.get()).collect();
         Self {
             entity_ids: LengthPrefixedVec::new(entity_ids),
         }

--- a/src/net/protocol/src/outgoing/remove_entities.rs
+++ b/src/net/protocol/src/outgoing/remove_entities.rs
@@ -1,6 +1,7 @@
 use temper_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_macros::{NetEncode, packet};
 
 #[derive(NetEncode)]
@@ -12,11 +13,11 @@ pub struct RemoveEntitiesPacket {
 impl RemoveEntitiesPacket {
     pub fn from_entities<T>(entity_ids: T) -> Self
     where
-        T: IntoIterator<Item = Identity>,
+        T: IntoIterator<Item = GameID>,
     {
         let entity_ids: Vec<VarInt> = entity_ids
             .into_iter()
-            .map(|entity| VarInt::new(entity.entity_id))
+            .map(|entity| entity.get())
             .collect();
         Self {
             entity_ids: LengthPrefixedVec::new(entity_ids),

--- a/src/net/protocol/src/outgoing/set_head_rotation.rs
+++ b/src/net/protocol/src/outgoing/set_head_rotation.rs
@@ -10,9 +10,9 @@ pub struct SetHeadRotationPacket {
 }
 
 impl SetHeadRotationPacket {
-    pub fn new(entity_id: i32, head_yaw: NetAngle) -> Self {
+    pub fn new(entity_id: VarInt, head_yaw: NetAngle) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id),
+            entity_id,
             head_yaw,
         }
     }

--- a/src/net/protocol/src/outgoing/spawn_entity.rs
+++ b/src/net/protocol/src/outgoing/spawn_entity.rs
@@ -4,6 +4,7 @@ use temper_codec::net_types::angle::NetAngle;
 use temper_codec::net_types::lpvec3::Lpvec3;
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::position::Position;
 use temper_components::player::rotation::Rotation;
 use temper_components::player::velocity::Velocity;
@@ -31,7 +32,7 @@ impl SpawnEntityPacket {
     /// This is useful when you have the component values directly
     /// rather than needing to query them.
     pub fn new(
-        entity_id: i32,
+        entity_id: VarInt,
         entity_uuid: u128,
         entity_type_id: i32,
         position: &Position,
@@ -42,7 +43,7 @@ impl SpawnEntityPacket {
         let (yaw, pitch) = rotation.yaw_pitch();
 
         Self {
-            entity_id: VarInt::new(entity_id),
+            entity_id,
             entity_uuid,
             r#type: VarInt::new(entity_type_id),
             x,
@@ -66,9 +67,9 @@ impl SpawnEntityPacket {
     pub fn entity(
         entity: Entity,
         entity_type_id: u16,
-        query: Query<(&Identity, &Position, &Rotation, &Velocity)>,
+        query: Query<(&Identity, &Position, &Rotation, &Velocity, &GameID)>,
     ) -> Result<Self, NetError> {
-        let (identity, position, rotation, vel) = query
+        let (identity, position, rotation, vel, game_id) = query
             .get(entity)
             .map_err(|e| NetError::ECSError(e.into()))?;
 
@@ -76,7 +77,7 @@ impl SpawnEntityPacket {
         let (yaw, pitch) = rotation.yaw_pitch();
 
         Ok(Self {
-            entity_id: VarInt::new(identity.entity_id),
+            entity_id: game_id.get(),
             entity_uuid: identity.uuid.as_u128(),
             r#type: VarInt::new(i32::from(entity_type_id)),
             x,

--- a/src/net/protocol/src/outgoing/update_entity_position.rs
+++ b/src/net/protocol/src/outgoing/update_entity_position.rs
@@ -1,5 +1,6 @@
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_macros::{NetEncode, packet};
 
 #[derive(NetEncode, Clone)]
@@ -13,9 +14,9 @@ pub struct UpdateEntityPositionPacket {
 }
 
 impl UpdateEntityPositionPacket {
-    pub fn new(entity_id: &Identity, delta_positions: (i16, i16, i16), on_ground: bool) -> Self {
+    pub fn new(entity_id: &GameID, delta_positions: (i16, i16, i16), on_ground: bool) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.entity_id),
+            entity_id: entity_id.get(),
             delta_x: delta_positions.0,
             delta_y: delta_positions.1,
             delta_z: delta_positions.2,

--- a/src/net/protocol/src/outgoing/update_entity_position.rs
+++ b/src/net/protocol/src/outgoing/update_entity_position.rs
@@ -1,5 +1,4 @@
 use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
 use temper_components::game_id::GameID;
 use temper_macros::{NetEncode, packet};
 

--- a/src/net/protocol/src/outgoing/update_entity_position_and_rotation.rs
+++ b/src/net/protocol/src/outgoing/update_entity_position_and_rotation.rs
@@ -1,6 +1,5 @@
 use temper_codec::net_types::angle::NetAngle;
 use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
 use temper_components::game_id::GameID;
 use temper_components::player::rotation::Rotation;
 use temper_macros::{NetEncode, packet};

--- a/src/net/protocol/src/outgoing/update_entity_position_and_rotation.rs
+++ b/src/net/protocol/src/outgoing/update_entity_position_and_rotation.rs
@@ -1,6 +1,7 @@
 use temper_codec::net_types::angle::NetAngle;
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::rotation::Rotation;
 use temper_macros::{NetEncode, packet};
 
@@ -18,13 +19,13 @@ pub struct UpdateEntityPositionAndRotationPacket {
 
 impl UpdateEntityPositionAndRotationPacket {
     pub fn new(
-        entity_id: &Identity,
+        entity_id: &GameID,
         delta_positions: (i16, i16, i16),
         new_rot: &Rotation,
         on_ground: bool,
     ) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.entity_id),
+            entity_id: entity_id.get(),
             delta_x: delta_positions.0,
             delta_y: delta_positions.1,
             delta_z: delta_positions.2,

--- a/src/net/protocol/src/outgoing/update_entity_rotation.rs
+++ b/src/net/protocol/src/outgoing/update_entity_rotation.rs
@@ -1,6 +1,7 @@
 use temper_codec::net_types::angle::NetAngle;
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::rotation::Rotation;
 use temper_macros::{NetEncode, packet};
 
@@ -13,9 +14,9 @@ pub struct UpdateEntityRotationPacket {
     pub on_ground: bool,
 }
 impl UpdateEntityRotationPacket {
-    pub fn new(entity_id: &Identity, new_rot: &Rotation, on_ground: bool) -> Self {
+    pub fn new(entity_id: &GameID, new_rot: &Rotation, on_ground: bool) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.entity_id),
+            entity_id: entity_id.get(),
             yaw: NetAngle::from_degrees(f64::from(new_rot.yaw)),
             pitch: NetAngle::from_degrees(f64::from(new_rot.pitch)),
             on_ground,

--- a/src/net/protocol/src/outgoing/update_entity_rotation.rs
+++ b/src/net/protocol/src/outgoing/update_entity_rotation.rs
@@ -1,6 +1,5 @@
 use temper_codec::net_types::angle::NetAngle;
 use temper_codec::net_types::var_int::VarInt;
-use temper_components::entity_identity::Identity;
 use temper_components::game_id::GameID;
 use temper_components::player::rotation::Rotation;
 use temper_macros::{NetEncode, packet};

--- a/src/net/runtime/src/conn_init/login.rs
+++ b/src/net/runtime/src/conn_init/login.rs
@@ -18,6 +18,7 @@ use temper_protocol::outgoing::update_tags::UPDATE_TAGS_PACKET;
 use temper_state::GlobalState;
 
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::gamemode::GameMode;
 use temper_components::player::offline_player_data::OfflinePlayerData;
 use temper_components::player::player_properties::{PlayerProperties, PlayerProperty};
@@ -46,7 +47,6 @@ use temper_protocol::outgoing::synchronize_player_position::SynchronizePlayerPos
 use tokio::net::tcp::OwnedReadHalf;
 use tracing::{debug, error, trace};
 use uuid::Uuid;
-use temper_components::game_id::GameID;
 // =================================================================================================
 // Helper Functions
 // =================================================================================================
@@ -550,7 +550,7 @@ pub(super) async fn login(
         });
 
     // Phase 3: Play State Setup
-    
+
     let player_game_id = GameID::new();
 
     // TODO: at some point this should be moved to the ECS

--- a/src/net/runtime/src/conn_init/login.rs
+++ b/src/net/runtime/src/conn_init/login.rs
@@ -46,6 +46,7 @@ use temper_protocol::outgoing::synchronize_player_position::SynchronizePlayerPos
 use tokio::net::tcp::OwnedReadHalf;
 use tracing::{debug, error, trace};
 use uuid::Uuid;
+use temper_components::game_id::GameID;
 // =================================================================================================
 // Helper Functions
 // =================================================================================================
@@ -225,7 +226,6 @@ async fn send_login_success(
     let player_identity = Identity {
         uuid: Uuid::from_u128(login_start.uuid),
         name: Some(login_start.username.clone()),
-        entity_id: login_start.uuid as i32,
     };
 
     // Wait for Login Acknowledged
@@ -359,7 +359,7 @@ async fn finish_configuration(
 /// Sends initial play state packets (login_play, abilities, op level).
 fn send_initial_play_packets(
     conn_write: &StreamWriter,
-    player_identity: &Identity,
+    player_id: &GameID,
     offline_data: &OfflinePlayerData,
     state: GlobalState,
 ) -> Result<(), NetError> {
@@ -367,7 +367,7 @@ fn send_initial_play_packets(
     let game_mode = offline_data.gamemode;
 
     conn_write.send_packet(LoginPlayPacket::new(
-        player_identity.entity_id,
+        player_id.get().0,
         game_mode as u8,
         &state.config,
     ))?;
@@ -379,7 +379,7 @@ fn send_initial_play_packets(
 
     // Send OP level (TODO: use actual player OP level)
     conn_write.send_packet(EntityStatus {
-        entity_id: player_identity.entity_id,
+        entity_id: player_id.get().0,
         status: 28, // OP level 4
     })?;
 
@@ -550,9 +550,11 @@ pub(super) async fn login(
         });
 
     // Phase 3: Play State Setup
+    
+    let player_game_id = GameID::new();
 
     // TODO: at some point this should be moved to the ECS
-    send_initial_play_packets(conn_write, &player_identity, &offline_data, state.clone())?;
+    send_initial_play_packets(conn_write, &player_game_id, &offline_data, state.clone())?;
     sync_player_position(
         conn_read,
         conn_write,
@@ -584,6 +586,7 @@ pub(super) async fn login(
         false,
         LoginResult {
             player_identity: Some(player_identity),
+            game_id: Some(player_game_id),
             compression: compressed,
             client_information_component: Some(client_info.into()),
             player_properties: Some(player_properties),

--- a/src/net/runtime/src/conn_init/mod.rs
+++ b/src/net/runtime/src/conn_init/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::Ordering;
 use temper_codec::decode::{NetDecode, NetDecodeOpts};
 use temper_codec::net_types::var_int::VarInt;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::client_information::ClientInformationComponent;
 use temper_components::player::player_properties::PlayerProperties;
 use temper_encryption::read::EncryptedReader;
@@ -23,7 +24,6 @@ use temper_text::{ComponentBuilder, NamedColor, TextComponent};
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::task::spawn_blocking;
 use tracing::{error, trace};
-use temper_components::game_id::GameID;
 
 /// Represents the result of a login attempt after the handshake process.
 ///

--- a/src/net/runtime/src/conn_init/mod.rs
+++ b/src/net/runtime/src/conn_init/mod.rs
@@ -23,6 +23,7 @@ use temper_text::{ComponentBuilder, NamedColor, TextComponent};
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::task::spawn_blocking;
 use tracing::{error, trace};
+use temper_components::game_id::GameID;
 
 /// Represents the result of a login attempt after the handshake process.
 ///
@@ -30,6 +31,7 @@ use tracing::{error, trace};
 /// - `compression`: Indicates whether network compression should be enabled for this connection.
 pub(crate) struct LoginResult {
     pub player_identity: Option<Identity>,
+    pub game_id: Option<GameID>,
     pub player_properties: Option<PlayerProperties>,
     pub compression: bool,
     pub client_information_component: Option<ClientInformationComponent>,

--- a/src/net/runtime/src/conn_init/status.rs
+++ b/src/net/runtime/src/conn_init/status.rs
@@ -115,6 +115,7 @@ pub(super) async fn status(
         true,
         LoginResult {
             player_identity: None,
+            game_id: None,
             compression: false,
             client_information_component: None,
             player_properties: None,

--- a/src/net/runtime/src/connection.rs
+++ b/src/net/runtime/src/connection.rs
@@ -154,7 +154,7 @@ impl StreamWriter {
         net_encode_opts: &NetEncodeOpts,
     ) -> Result<(), NetError> {
         if !self.running.load(Ordering::Relaxed) {
-            warn!("Attempted to send packet on closed connection");
+            trace!("Attempted to send packet on closed connection");
             return Ok(());
         }
 
@@ -328,6 +328,9 @@ pub async fn handle_connection(
                     NetError::InvalidState(state) => {
                         warn!("Client sent invalid handshake state: {}", state);
                     }
+                    NetError::ConnectionDropped | NetError::Packet(PacketError::DroppedConnection) => {
+                        debug!("Client dropped connection during handshake");
+                    }
                     _ => {
                         error!("Unhandled handshake error: {}", err);
                     }
@@ -345,6 +348,8 @@ pub async fn handle_connection(
     // Send the new connection data to ECS world
     let (entity_return, entity_recv) = oneshot::channel();
     let (disconnect_return, mut disconnect_receiver) = oneshot::channel();
+    
+    let player_name = login_result.player_identity.clone().map(|id| id.name.unwrap_or_default());
 
     new_join_sender
         .send(NewConnection {
@@ -367,6 +372,14 @@ pub async fn handle_connection(
         Err(err) => {
             error!("Failed to receive entity ID: {:?}", err);
             return Err(NetError::Misc("Failed to receive entity ID".to_string()));
+        }
+    };
+
+    let player_name = match player_name {
+        Some(name) => name,
+        None => {
+            error!("Player identity not found after handshake, using placeholder");
+            format!("player-no-id_{:X}", entity.to_bits())
         }
     };
 
@@ -396,11 +409,11 @@ pub async fn handle_connection(
                     },
                     Err(err) => {
                         if let PacketError::DroppedConnection | PacketError::NetTypeError(NetTypesError::ConnectionDropped) = err {
-                            trace!("Connection dropped for entity {:?}", entity);
+                            trace!("Connection dropped for player {:?}", player_name);
                             running.store(false, Ordering::Relaxed);
                             state.players.disconnect(entity, None);
                         } else {
-                            error!("Failed to read packet skeleton: {:?} for {:?}", err, entity);
+                            error!("Failed to read packet skeleton: {:?} for {:?}", err, player_name);
                             running.store(false, Ordering::Relaxed);
                             state.players.disconnect(entity, None);
                         }
@@ -410,7 +423,7 @@ pub async fn handle_connection(
             }
 
             _ = &mut disconnect_receiver => {
-                debug!("Received disconnect signal for entity {:?}", entity);
+                debug!("Received disconnect signal for player {:?}", player_name);
                 running.store(false, Ordering::Relaxed);
                 break 'recv;
             }
@@ -420,27 +433,28 @@ pub async fn handle_connection(
         match handle_packet(
             packet_skele.id,
             entity,
+            player_name.clone(),
             &mut packet_skele.data,
             packet_sender.clone(),
         )
-        .instrument(debug_span!("eid", %entity))
+        .instrument(debug_span!("player", %player_name))
         .into_inner()
         {
             Ok(()) => {
                 trace!(
-                    "Packet {:02X} successfully handled for entity {:?}",
-                    packet_skele.id, entity
+                    "Packet {:02X} successfully handled for player {:?}",
+                    packet_skele.id, player_name
                 );
             }
             Err(err) => match &err {
                 NetError::Packet(InvalidPacket(id)) => {
                     trace!(
-                        "Unimplemented packet 0x{:02X} received for entity {:?}",
-                        id, entity
+                        "Unimplemented packet 0x{:02X} received for player {:?}",
+                        id, player_name
                     );
                 }
                 _ => {
-                    warn!("Error handling packet for {:?}: {:?}", entity, err);
+                    warn!("Error handling packet for {:?}: {:?}", player_name, err);
                     running.store(false, Ordering::Relaxed);
                     state.players.disconnect(entity, None);
                     break 'recv;

--- a/src/net/runtime/src/connection.rs
+++ b/src/net/runtime/src/connection.rs
@@ -29,6 +29,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing::{Instrument, debug, debug_span, error, trace, warn};
+use temper_components::game_id::GameID;
 
 /// The maximum time allowed for a client to complete its initial handshake.
 /// Connections exceeding this duration will be dropped to avoid resource hogging.
@@ -235,6 +236,7 @@ impl StreamWriter {
 pub struct NewConnection {
     pub stream: StreamWriter,
     pub player_identity: Identity,
+    pub game_id: GameID,
     pub client_information_component: ClientInformationComponent,
     pub player_properties: PlayerProperties,
     pub permissions: PlayerPermission,
@@ -348,6 +350,7 @@ pub async fn handle_connection(
         .send(NewConnection {
             stream,
             player_identity: login_result.player_identity.unwrap_or_default(),
+            game_id: login_result.game_id.unwrap_or_default(),
             player_properties: login_result.player_properties.unwrap_or_default(),
             entity_return,
             disconnect_handle: disconnect_return,

--- a/src/net/runtime/src/connection.rs
+++ b/src/net/runtime/src/connection.rs
@@ -9,6 +9,7 @@ use temper_codec::encode::NetEncode;
 use temper_codec::encode::NetEncodeOpts;
 use temper_codec::net_types::NetTypesError;
 use temper_components::entity_identity::Identity;
+use temper_components::game_id::GameID;
 use temper_components::player::client_information::ClientInformationComponent;
 use temper_components::player::player_properties::PlayerProperties;
 use temper_encryption::read::EncryptedReader;
@@ -29,7 +30,6 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing::{Instrument, debug, debug_span, error, trace, warn};
-use temper_components::game_id::GameID;
 
 /// The maximum time allowed for a client to complete its initial handshake.
 /// Connections exceeding this duration will be dropped to avoid resource hogging.
@@ -328,7 +328,8 @@ pub async fn handle_connection(
                     NetError::InvalidState(state) => {
                         warn!("Client sent invalid handshake state: {}", state);
                     }
-                    NetError::ConnectionDropped | NetError::Packet(PacketError::DroppedConnection) => {
+                    NetError::ConnectionDropped
+                    | NetError::Packet(PacketError::DroppedConnection) => {
                         debug!("Client dropped connection during handshake");
                     }
                     _ => {
@@ -348,8 +349,11 @@ pub async fn handle_connection(
     // Send the new connection data to ECS world
     let (entity_return, entity_recv) = oneshot::channel();
     let (disconnect_return, mut disconnect_receiver) = oneshot::channel();
-    
-    let player_name = login_result.player_identity.clone().map(|id| id.name.unwrap_or_default());
+
+    let player_name = login_result
+        .player_identity
+        .clone()
+        .map(|id| id.name.unwrap_or_default());
 
     new_join_sender
         .send(NewConnection {

--- a/src/net/runtime/src/connection.rs
+++ b/src/net/runtime/src/connection.rs
@@ -437,7 +437,7 @@ pub async fn handle_connection(
         match handle_packet(
             packet_skele.id,
             entity,
-            player_name.clone(),
+            player_name.as_str(),
             &mut packet_skele.data,
             packet_sender.clone(),
         )


### PR DESCRIPTION
This will just make it a bit easier to avoid colliding IDs since they are now mostly random and reset on server reboots. Also cleaned up a bunch of logging stuff to be less noisy