### PR TITLE
Sync sub-crate version with workspace

### DIFF
--- a/src/adapters/anvil/Cargo.toml
+++ b/src/adapters/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-anvil"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/adapters/nbt/Cargo.toml
+++ b/src/adapters/nbt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-nbt"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin-cli"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/app/import/Cargo.toml
+++ b/src/app/import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin-import"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/app/runtime/Cargo.toml
+++ b/src/app/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin-runtime"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/app/validate/Cargo.toml
+++ b/src/app/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin-validate"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/base/general_purpose/Cargo.toml
+++ b/src/base/general_purpose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-general-purpose"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/base/logging/Cargo.toml
+++ b/src/base/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-logging"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/base/macros/Cargo.toml
+++ b/src/base/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-macros"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [features]

--- a/src/base/profiling/Cargo.toml
+++ b/src/base/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-profiling"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/base/threadpool/Cargo.toml
+++ b/src/base/threadpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-threadpool"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/blocks/crates/build/Cargo.toml
+++ b/src/blocks/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-blocks-build"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/blocks/crates/data/Cargo.toml
+++ b/src/blocks/crates/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-block-data"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/blocks/crates/generated/Cargo.toml
+++ b/src/blocks/crates/generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-blocks-generated"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/blocks/crates/property/Cargo.toml
+++ b/src/blocks/crates/property/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-block-properties"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/command-infra/Cargo.toml
+++ b/src/command-infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-command-infra"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/components/Cargo.toml
+++ b/src/components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-components"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 description = "Temper components"
 

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-config"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 description = "Temper configuration utilities"
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temper-core"
 description = "This crate defines all the primitives, traits and logics used in Temper codebase."
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/dashboard/Cargo.toml
+++ b/src/dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-dashboard"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-data"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 build = "build/build.rs"
 

--- a/src/default_commands/Cargo.toml
+++ b/src/default_commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-default-commands"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/entities/Cargo.toml
+++ b/src/entities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-entities"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/background/Cargo.toml
+++ b/src/game_systems/src/background/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "background"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/interactions/Cargo.toml
+++ b/src/game_systems/src/interactions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interactions"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/mobs/Cargo.toml
+++ b/src/game_systems/src/mobs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobs"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/packets/Cargo.toml
+++ b/src/game_systems/src/packets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packets"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/pathfinding/Cargo.toml
+++ b/src/game_systems/src/pathfinding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathfinding"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/physics/Cargo.toml
+++ b/src/game_systems/src/physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "physics"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/player/Cargo.toml
+++ b/src/game_systems/src/player/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "player"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/shutdown/Cargo.toml
+++ b/src/game_systems/src/shutdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shutdown"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/game_systems/src/world/Cargo.toml
+++ b/src/game_systems/src/world/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/inventories/Cargo.toml
+++ b/src/inventories/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-inventories"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/messages/Cargo.toml
+++ b/src/messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-messages"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 description = "Defines all Bevy ECS messages for Temper."
 

--- a/src/net/codec/Cargo.toml
+++ b/src/net/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-codec"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/net/encryption/Cargo.toml
+++ b/src/net/encryption/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-encryption"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/net/protocol/Cargo.toml
+++ b/src/net/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-protocol"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/net/runtime/Cargo.toml
+++ b/src/net/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-net-runtime"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/registry/Cargo.toml
+++ b/src/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-registry"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 build = "build.rs"
 

--- a/src/scheduler/Cargo.toml
+++ b/src/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-scheduler"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/state/Cargo.toml
+++ b/src/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-state"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temper-storage"
 description = "Implements storage capabilities of Temper for world persistence and on-disk resource parsing."
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/text/Cargo.toml
+++ b/src/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-text"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temper-utils"
 description = "Collection of utilities for use within Temper codebase."
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/Cargo.toml
+++ b/src/world/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temper-world"
 description = "Temper specific world definition and implementation of a Minecraft World and related logic."
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/world/db/Cargo.toml
+++ b/src/world/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-db"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/format/Cargo.toml
+++ b/src/world/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-world-format"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/Cargo.toml
+++ b/src/world/gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-gen"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/core/Cargo.toml
+++ b/src/world/gen/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-core"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/generators/normal/Cargo.toml
+++ b/src/world/gen/generators/normal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "normal"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/generators/skyblock/Cargo.toml
+++ b/src/world/gen/generators/skyblock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyblock"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/generators/superflat/Cargo.toml
+++ b/src/world/gen/generators/superflat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superflat"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/scheduler/Cargo.toml
+++ b/src/world/gen/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-scheduler"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/src/world/gen/structures/Cargo.toml
+++ b/src/world/gen/structures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-structures"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2024"
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temper-tests"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This PR makes all sub-crates have the same version as the workspace. Doesn't really change anything but does make the build logs a little more consistent